### PR TITLE
update list of known protocols when we receive a corresponding PropertyNotify event

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -2382,6 +2382,8 @@ Frame::handlePropertyChange(XPropertyEvent *ev, Client *client)
                 incrAttention();
             }
         }
+    } else if (ev->atom == X11::getAtom(WM_PROTOCOLS)) {
+      client->getWMProtocols();
     }
 }
 


### PR DESCRIPTION
hi!

some apps, Java in particular, apparently, change WM_PROPERTY during startup. Pekwm currently disregards this events, and memoizes the protocols a client supports.

This is a bad combination, because it means we never learn about protocol changes. This fix just rereads protocols whenever a corresponding event comes through.

https://youtrack.jetbrains.com/issue/IDEA-197344 describes a problem that occurs without this fix, FWIW.