### PR TITLE
Fix title width calculation when TopLeft and TopRight corners are wider than the border width

### DIFF
--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -847,7 +847,7 @@ PDecor::loadDecor(void)
 
     // Update title position.
     if (_data->getTitleWidthMin() == 0) {
-        _title_wo.move(borderTopLeft(), borderTop());
+        _title_wo.move(borderTop(), borderTop());
         _need_shape = false;
     } else {
         _title_wo.move(0, 0);
@@ -2046,8 +2046,8 @@ PDecor::calcTitleWidth(void)
 
     if (_data->getTitleWidthMin() == 0) {
         width = _gm.width;
-        if (width > (borderTopLeft() + borderTopRight())) {
-            width -= borderTopLeft() + borderTopRight();
+        if (borderTop() && (width > (borderLeft() + borderRight()))) {
+            width -= borderLeft() + borderRight();
         }
 
     } else {


### PR DESCRIPTION
Themes with corners wider than the border width don't display correctly since 0.1.3:
![pekwm_corner_incorrect](https://user-images.githubusercontent.com/11165868/102544919-d1ea8d00-40b5-11eb-944c-3265aad0b71b.png)

Correct window title after change:
![pekwm_corner_correct](https://user-images.githubusercontent.com/11165868/102544974-e890e400-40b5-11eb-8eaa-11a2f068ab84.png)

I haven't found any side effects so far.

