### PR TITLE
Update install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,4 +1,19 @@
 INSTALL
 =======
 
-Visit http://www.pekwm.org/ for help on installing pekwm. 
+If you want to install pekwm from source, follow these steps:
+
+1. Get the sources:
+
+    git clone https://github.com/pekdon/pekwm.git
+
+2. Build with cmake:
+
+    cd pekwm
+    mkdir build && cd build
+    cmake ..
+    make
+
+3. Install as root:
+
+    make install


### PR DESCRIPTION
As pekwm now uses cmake instead of autotools and https://pekwm.org doesn't provide install instructions, I figured I'd update the INSTALL file.

@pekdon What about adding install instructions (also) to the README? As a result they would be visible on the GitHub page of the project.