### PR TITLE
Geometry percent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,23 @@
+pekwm-0.2.0
+===========
+
+New
+---
+
+
+Updated
+-------
+
+**SetGeometry** now support specifying size and position in % of the
+screen or active head.
+
+Examples:
+
+```
+SetGeometry 100%x50%+0+0 Current HonourStrut
+SetGeometry 100x100% Screen
+```
+
+Removed
+-------
+

--- a/src/Action.cc
+++ b/src/Action.cc
@@ -1,0 +1,13 @@
+//
+// x11.cc for pekwm
+// Copyright (C) 2020 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include "config.h"
+
+#include "Action.hh"
+
+std::string Action::_empty_string = "";

--- a/src/Action.hh
+++ b/src/Action.hh
@@ -11,6 +11,7 @@
 
 #include "config.h"
 
+#include "x11.hh"
 #include "Types.hh"
 
 #include <vector>
@@ -153,39 +154,63 @@ namespace ActionUtil {
 
 class Action {
 public:
-    Action(void)
-    { 
-        clear();
+    Action()
+        : _action(ACTION_UNSET)
+    {
     }
-    
+
     Action(uint action)
     {
-        clear();
         _action = action;
     }
+
     ~Action(void)
     {
     }
 
     inline uint getAction(void) const { return _action; }
-    inline int getParamI(uint n) const { return _param_i[(n < 3) ? n : 0]; }
-    inline const std::string &getParamS(void) const { return _param_s; }
+    inline int getParamI() const {
+        return getParamI(0);
+    }
+    inline int getParamI(uint n) const {
+        return n < _i.size() ? _i[n] : 0;
+    }
+    inline const std::string &getParamS(void) const {
+        return getParamS(0);
+    }
+    inline const std::string &getParamS(uint n) const {
+        return n < _s.size() ? _s[n] : _empty_string;
+    }
 
     inline void setAction(uint action) { _action = action; }
-    inline void setParamI(uint n, int param) { _param_i[(n < 3) ? n : 0] = param; }
-    inline void setParamS(const std::string param) { _param_s = param; }
+    inline void setParamI(uint n, int param) {
+        while (n >= _i.size()) {
+            _i.push_back(0);
+        }
+        _i[n] = param;
+    }
+    inline void setParamS(const std::string param) {
+        setParamS(0, param);
+    }
+    inline void setParamS(uint n, const std::string param) {
+        while (n >= _s.size()) {
+            _s.push_back("");
+        }
+        _s[n] = param;
+    }
 
     inline void clear()
     {
         _action = ACTION_UNSET;
-        _param_s.clear();
-        memset(_param_i, '\0', sizeof(_param_i));
+        _i.clear();
+        _s.clear();
     }
 private:
     uint _action;
+    std::vector<int> _i;
+    std::vector<std::string> _s;
 
-    int _param_i[3];
-    std::string _param_s;
+    static std::string _empty_string;
 };
 
 class ActionEvent {

--- a/src/ActionHandler.cc
+++ b/src/ActionHandler.cc
@@ -142,7 +142,7 @@ ActionHandler::handleAction(const ActionPerformed &ap)
                 client->kill();
                 break;
             case ACTION_SET_GEOMETRY:
-                frame->setGeometry(it->getParamS(), it->getParamI(0));
+                frame->setGeometry(it->getParamS(), it->getParamI(0), it->getParamI(1) == 1);
                 break;
             case ACTION_RAISE:
                 if (it->getParamI(0)) {

--- a/src/AutoProperties.cc
+++ b/src/AutoProperties.cc
@@ -14,6 +14,7 @@
 #include "AutoProperties.hh"
 #include "Config.hh"
 #include "Util.hh"
+#include "x11.hh"
 
 using std::cerr;
 using std::endl;
@@ -579,10 +580,7 @@ AutoProperties::setDefaultTypeProperties(void)
     if (! findWindowTypeProperty(WINDOW_TYPE_DESKTOP)) {
         AutoProperty *prop = new AutoProperty();
         prop->maskAdd(AP_CLIENT_GEOMETRY);
-        prop->client_gm_mask =
-                XParseGeometry("0x0+0+0",
-                     &prop->client_gm.x, &prop->client_gm.y,
-                     &prop->client_gm.width, &prop->client_gm.height);
+        prop->client_gm_mask = X11::parseGeometry("0x0+0+0", prop->client_gm);
         prop->maskAdd(AP_STICKY);
         prop->sticky = true;
         prop->maskAdd(AP_TITLEBAR);
@@ -733,16 +731,12 @@ AutoProperties::parseAutoPropertyValue(CfgParser::Entry *section, AutoProperty *
         case AP_FRAME_GEOMETRY:
             prop->maskAdd(AP_FRAME_GEOMETRY);
             prop->frame_gm_mask =
-                XParseGeometry((char*) (*it)->getValue().c_str(),
-                             &prop->frame_gm.x, &prop->frame_gm.y,
-                             &prop->frame_gm.width, &prop->frame_gm.height);
+                X11::parseGeometry((*it)->getValue(), prop->frame_gm);
             break;
         case AP_CLIENT_GEOMETRY:
             prop->maskAdd(AP_CLIENT_GEOMETRY);
             prop->client_gm_mask =
-                XParseGeometry((char*) (*it)->getValue().c_str(),
-                       &prop->client_gm.x, &prop->client_gm.y,
-                       &prop->client_gm.width, &prop->client_gm.height);
+                X11::parseGeometry((*it)->getValue(), prop->client_gm);
             break;
         case AP_LAYER:            
             prop->layer = Config::instance()->getLayer((*it)->getValue());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ configure_file(${CMAKE_SOURCE_DIR}/CMake/config.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
 set(libpekwm_SOURCES
+  Action.cc
   ActionHandler.cc
   ActionMenu.cc
   AutoProperties.cc

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -977,15 +977,7 @@ Config::parseAction(const std::string &action_string, Action &action, uint mask)
                     action.setParamS(tok[1]);
                     break;
                 case ACTION_SET_GEOMETRY:
-                    // Add optional head parameter, -1 means screen.
-                    Util::splitString(tok[1], tok, " \t", 2);
-                    if (tok.size() == 4) {
-                        action.setParamS(tok[2]);
-                        action.setParamI(0, strtol(tok[3].c_str(), 0, 10));
-                    } else {
-                        action.setParamS(tok[1]);
-                        action.setParamI(0, -1);
-                    }
+                    parseActionSetGeometry(action, tok[1]);
                     break;
                 case ACTION_ACTIVATE_CLIENT_REL:
                 case ACTION_MOVE_CLIENT_REL:
@@ -1857,3 +1849,40 @@ Config::parseOpacity(const std::string value, uint &focused, uint &unfocused)
     return true;
 }
 
+/**
+ * Parse SetGeometry action parameters.
+ *
+ * SetGeometry 1x+0+0 [(screen|current|0-9) [HonourStrut]]
+ */
+void
+Config::parseActionSetGeometry(Action& action, const std::string &str)
+{
+    std::vector<std::string> tok;
+
+    if (! Util::splitString(str, tok, " \t", 3)) {
+        return;
+    }
+
+    // geometry
+    action.setParamS(tok[0]);
+
+    // screen, current head or head number
+    if (tok.size() > 1) {
+        if (strcasecmp(tok[1].c_str(), "SCREEN") == 0) {
+            action.setParamI(0, -1);
+        } else if (strcasecmp(tok[1].c_str(), "CURRENT") == 0) {
+            action.setParamI(0, -2);
+        } else {
+            action.setParamI(0, strtol(tok[1].c_str(), 0, 10));
+        }
+    } else {
+        action.setParamI(0, -1);
+    }
+
+    // honour strut option
+    if (tok.size() > 2) {
+        action.setParamI(1, strcasecmp(tok[2].c_str(), "HONOURSTRUT") ? 0 : 1);
+    } else {
+        action.setParamI(1, 0);
+    }
+}

--- a/src/Config.hh
+++ b/src/Config.hh
@@ -243,6 +243,9 @@ public:
 
     static bool parseOpacity(const std::string value, uint &focused, uint &unfocused);
 
+protected:
+    static void parseActionSetGeometry(Action& action, const std::string &str);
+
 private:
     bool tryHardLoadConfig(CfgParser &cfg, std::string &file);
     void copyConfigFiles(void);

--- a/src/Frame.hh
+++ b/src/Frame.hh
@@ -110,8 +110,8 @@ public:
 
     inline const ClassHint* getClassHint(void) const { return _class_hint; }
 
-    void setGeometry(const std::string geometry, int head=-1);
-    void setGeometry(const Geometry &geometry, int gm_mask, int head=-1);
+    void setGeometry(const std::string geometry, int head=-1, bool honour_strut=false);
+    void setGeometry(const Geometry &geometry, int gm_mask, const Geometry &head);
 
     void growDirection(uint direction);
     void moveToHead(int head_nr);
@@ -163,6 +163,9 @@ protected:
     std::string getDecorName(void);
     // END - PDecor interface
 
+    static void applyGeometry(Geometry &gm, const Geometry &ap_gm, int mask);
+    static void applyGeometry(Geometry &gm, const Geometry &ap_gm, int mask, const Geometry &screen_gm);
+
 private:
     void handleClientStateMessage(XClientMessageEvent *ev, Client *client);
     static StateAction getStateActionFromMessage(XClientMessageEvent *ev);
@@ -182,8 +185,6 @@ private:
     void applyState(Client *cl);
 
     void setupAPGeometry(Client *client, AutoProperty *ap);
-    void applyGeometry(Geometry &gm, const Geometry &ap_gm, int mask);
-    void applyGeometry(Geometry &gm, const Geometry &ap_gm, int mask, const Geometry &screen_gm);
 
     void setActiveTitle(void);
 

--- a/src/x11.hh
+++ b/src/x11.hh
@@ -38,6 +38,24 @@ extern unsigned int xerrors_count; /**< Number of X errors occured. */
 }
 
 /**
+ * Bitmask values for parseGeometry result.
+ */
+enum XGeometryMask {
+    NO_VALUE = 0,
+    X_VALUE = 1 << 0,
+    Y_VALUE = 1 << 1,
+    WIDTH_VALUE = 1 << 2,
+    HEIGHT_VALUE = 1 << 3,
+    ALL_VALUES = 1 << 4,
+    X_NEGATIVE = 1 << 5,
+    Y_NEGATIVE = 1 << 6,
+    X_PERCENT = 1 << 7,
+    Y_PERCENT = 1 << 8,
+    WIDTH_PERCENT = 1 << 9,
+    HEIGHT_PERCENT = 1 << 10
+};
+
+/**
  * Class holding information about screen edge allocation.
  */
 class Strut {
@@ -283,6 +301,8 @@ public:
 
     // helper functions
 
+    static int parseGeometry(const std::string& str, Geometry& gm);
+
     inline static
     void keepVisible(Geometry &gm) {
         if (gm.x > static_cast<int>(getWidth()) - 3) {
@@ -430,6 +450,9 @@ public:
     }
 #endif
 
+protected:
+    static int parseGeometryVal(const char *c_str, const char *e_end, int &val_ret);
+
 private:
     // squared distance because computing with sqrt is expensive
 
@@ -443,6 +466,8 @@ private:
     static void initHeads(void);
     static void initHeadsRandr(void);
     static void initHeadsXinerama(void);
+
+private:
 
     static Display *_dpy;
     static bool _honour_randr; /**< Boolean flag if randr should be honoured. */
@@ -470,7 +495,7 @@ private:
     static bool _has_extension_xrandr;
     static int _event_xrandr;
 
-    static vector<Head> _heads; //! Array of head information
+    static std::vector<Head> _heads; //! Array of head information
     static uint _last_head; //! Last accessed head
 
     static uint _server_grabs;
@@ -481,7 +506,7 @@ private:
     static Time _last_click_time[BUTTON_NO - 1];
 
     static Strut _strut;
-    static vector<Strut*> _struts;
+    static std::vector<Strut*> _struts;
 
     static std::array<Cursor, MAX_NR_CURSOR> _cursor_map;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,38 +2,74 @@ set(common_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src
                         ${ICONV_INCLUDE_DIR} ${X11_INCLUDE_DIR})
 set(common_LIBRARIES ${ICONV_LIBRARIES} ${X11_LIBRARIES})
 
-if (X11_Xshape_FOUND)
+if (ENABLE_SHAPE AND X11_Xshape_FOUND)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${X11_Xshape_INCLUDE_PATH})
   set(common_LIBRARIES ${common_LIBRARIES} ${X11_Xshape_LIB})
-endif (X11_Xshape_FOUND)
+endif (ENABLE_SHAPE AND X11_Xshape_FOUND)
 
-if (X11_Xinerama_FOUND)
+if (ENABLE_XINERAMA AND X11_Xinerama_FOUND)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${X11_Xinerama_INCLUDE_PATH})
   set(common_LIBRARIES ${common_LIBRARIES} ${X11_Xinerama_LIB})
-endif (X11_Xinerama_FOUND)
+endif (ENABLE_XINERAMA AND X11_Xinerama_FOUND)
 
-if (X11_Xft_FOUND AND FREETYPE_FOUND)
+if (ENABLE_XFT AND X11_Xft_FOUND AND FREETYPE_FOUND)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${X11_Xft_INCLUDE_PATH} ${FREETYPE_INCLUDE_DIRS})
   set(common_LIBRARIES ${common_LIBRARIES} ${X11_Xft_LIB} ${FREETYPE_LIBRARIES})
-endif (X11_Xft_FOUND AND FREETYPE_FOUND)
+endif (ENABLE_XFT AND X11_Xft_FOUND AND FREETYPE_FOUND)
 
-if (PNG_FOUND)
+if (ENABLE_IMAGE_PNG AND PNG_FOUND)
+  set(libpekwm_SOURCES ${libpekwm_SOURCES} PImageLoaderPng.cc)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${PNG_INCLUDE_DIR})
   set(common_LIBRARIES ${common_LIBRARIES} ${PNG_LIBRARY_RELEASE})
-endif (PNG_FOUND)
+endif (ENABLE_IMAGE_PNG AND PNG_FOUND)
 
-if (X11_Xpm_FOUND)
+if (ENABLE_IMAGE_XPM AND X11_Xpm_FOUND)
+  set(libpekwm_SOURCES ${libpekwm_SOURCES} PImageLoaderXpm.cc)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${X11_Xpm_INCLUDE_PATH})
   set(common_LIBRARIES ${common_LIBRARIES} ${X11_Xpm_LIB})
-endif (X11_Xpm_FOUND)
+endif (ENABLE_IMAGE_XPM AND X11_Xpm_FOUND)
 
-if (X11_Xrandr_FOUND)
+if (ENABLE_RANDR AND X11_Xrandr_FOUND)
   set(common_INCLUDE_DIRS ${common_INCLUDE_DIRS} ${X11_Xrandr_INCLUDE_PATH})
   set(common_LIBRARIES ${common_LIBRARIES} ${X11_Xrandr_LIB})
-endif (X11_Xrandr_FOUND)
+endif (ENABLE_RANDR AND X11_Xrandr_FOUND)
+
+add_executable(test_Action test_Action.cc)
+add_test(Action test_Action)
+target_include_directories(test_Action PUBLIC ${common_INCLUDE_DIRS})
+target_link_libraries(test_Action libpekwm ${common_LIBRARIES})
+set_target_properties(test_Action PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+
+add_executable(test_Config test_Config.cc)
+add_test(Config test_Config)
+target_include_directories(test_Config PUBLIC ${common_INCLUDE_DIRS})
+target_link_libraries(test_Config libpekwm ${common_LIBRARIES})
+set_target_properties(test_Config PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+
+add_executable(test_Frame test_Frame.cc)
+add_test(Frame test_Frame)
+target_include_directories(test_Frame PUBLIC ${common_INCLUDE_DIRS})
+target_link_libraries(test_Frame libpekwm ${common_LIBRARIES})
+set_target_properties(test_Frame PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
 
 add_executable(test_Util test_Util.cc)
 add_test(Util test_Util)
-
 target_include_directories(test_Util PUBLIC ${common_INCLUDE_DIRS})
 target_link_libraries(test_Util libpekwm ${common_LIBRARIES})
+set_target_properties(test_Util PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+
+add_executable(test_x11 test_x11.cc)
+add_test(x11 test_x11)
+set_target_properties(test_x11 PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+target_include_directories(test_x11 PUBLIC ${common_INCLUDE_DIRS})
+target_link_libraries(test_x11 libpekwm ${common_LIBRARIES})

--- a/test/test_Action.cc
+++ b/test/test_Action.cc
@@ -1,0 +1,82 @@
+//
+// test_Action.cc for pekwm
+// Copyright (C) 2020 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include <iostream>
+
+#include "test.hh"
+#include "Action.hh"
+
+class TestAction : public Action {
+public:
+    static void testConstruct(void) {
+        Action a;
+        ASSERT_EQUAL("construct", std::string("empty"),
+                     ACTION_UNSET, a.getAction());
+        Action a1(ACTION_FOCUS);
+        ASSERT_EQUAL("construct", std::string("action"),
+                     ACTION_FOCUS, a1.getAction());
+    }
+
+    static void testParamI(void) {
+        Action a;
+        ASSERT_EQUAL("testParamI", std::string("not set"),
+                     0, a.getParamI(0));
+
+        a.setParamI(0, 1);
+        ASSERT_EQUAL("testParamI", std::string("set/get first"),
+                     1, a.getParamI(0));
+
+        a.setParamI(2, 3);
+        ASSERT_EQUAL("testParamI", std::string("gap"),
+                     1, a.getParamI(0));
+        ASSERT_EQUAL("testParamI", std::string("gap"),
+                     0, a.getParamI(1));
+        ASSERT_EQUAL("testParamI", std::string("gap"),
+                     3, a.getParamI(2));
+
+        a.setParamI(1, 2);
+        ASSERT_EQUAL("testParamI", std::string("second"),
+                     2, a.getParamI(1));
+    }
+
+    static void testParamS(void) {
+        Action a;
+        ASSERT_EQUAL("testParamS", std::string("not set"),
+                     std::string(""), a.getParamS());
+
+        a.setParamS("first");
+        ASSERT_EQUAL("testParamS", std::string("set/get first"),
+                     std::string("first"), a.getParamS());
+
+        a.setParamS(2, "third");
+        ASSERT_EQUAL("testParamS", std::string("gap"),
+                     std::string("first"), a.getParamS(0));
+        ASSERT_EQUAL("testParamS", std::string("gap"),
+                     std::string(""), a.getParamS(1));
+        ASSERT_EQUAL("testParamS", std::string("gap"),
+                     std::string("third"), a.getParamS(2));
+
+        a.setParamS(1, "second");
+        ASSERT_EQUAL("testParamS", std::string("second"),
+                     std::string("second"), a.getParamS(1));
+    }
+};
+
+int
+main(int argc, char *argv[])
+{
+    try {
+        TestAction::testConstruct();
+        TestAction::testParamI();
+        TestAction::testParamS();
+        return 0;
+    } catch (AssertFailed &ex) {
+        std::cerr << ex.file() << ":" << ex.line() << " " << ex.msg() << std::endl;
+        return 1;
+    }
+}

--- a/test/test_Config.cc
+++ b/test/test_Config.cc
@@ -1,0 +1,65 @@
+//
+// test_Config.cc for pekwm
+// Copyright (C) 2020 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include <iostream>
+
+#include "test.hh"
+#include "Config.hh"
+
+class TestConfig : public Config {
+public:
+    static void testParseActionSetGeometry(void) {
+        Action a_empty;
+        Config::parseActionSetGeometry(a_empty, "");
+        assertAction("parseActionSetGeometry empty", a_empty, { }, { });
+
+        Action a_no_head;
+        Config::parseActionSetGeometry(a_no_head, "10x10+0+0");
+        assertAction("parseActionSetGeometry no head", a_no_head, { -1, 0 }, { "10x10+0+0" });
+
+        Action a_head;
+        Config::parseActionSetGeometry(a_head, "10x10+0+0 0");
+        assertAction("parseActionSetGeometry head", a_head, { 0, 0 }, { "10x10+0+0" });
+
+        Action a_screen;
+        Config::parseActionSetGeometry(a_screen, "10x10+0+0 screen");
+        assertAction("parseActionSetGeometry screen", a_screen, { -1, 0 }, { "10x10+0+0" });
+
+        Action a_current;
+        Config::parseActionSetGeometry(a_current, "10x10+0+0 current");
+        assertAction("parseActionSetGeometry current", a_current, { -2, 0 }, { "10x10+0+0" });
+
+        Action a_strut;
+        Config::parseActionSetGeometry(a_strut, "10x10+0+0 current HonourStrut");
+        assertAction("parseActionSetGeometry strut", a_strut, { -2, 1 }, { "10x10+0+0" });
+    }
+
+    static void assertAction(std::string msg, const Action& action,
+                             std::vector<int> e_int, std::vector<std::string> e_str) {
+        for (int i = 0; i < e_int.size(); i++) {
+            ASSERT_EQUAL("assertAction", msg + " I " + std::to_string(i),
+                         e_int[i], action.getParamI(i));
+        }
+        for (int i = 0; i < e_str.size(); i++) {
+            ASSERT_EQUAL("assertAction", msg + " S " + std::to_string(i),
+                         e_str[i], action.getParamS(i));
+        }
+    }
+};
+
+int
+main(int argc, char *argv[])
+{
+    try {
+        TestConfig::testParseActionSetGeometry();
+        return 0;
+    } catch (AssertFailed &ex) {
+        std::cerr << ex.file() << ":" << ex.line() << " " << ex.msg() << std::endl;
+        return 1;
+    }
+}

--- a/test/test_Frame.cc
+++ b/test/test_Frame.cc
@@ -1,0 +1,60 @@
+//
+// test_Frame.cc for pekwm
+// Copyright (C) 2020 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include <iostream>
+
+#include "test.hh"
+#include "Frame.hh"
+
+class TestFrame : public Frame {
+public:
+    static void testApplyGeometry(void) {
+        assertApplyGeometry("negative pos",
+                            Geometry(), Geometry(-0, 102, 102, 102),
+                            X_VALUE | Y_VALUE | WIDTH_VALUE | HEIGHT_VALUE | X_NEGATIVE,
+                            Geometry(0, 0, 1024, 768),
+                            // expected
+                            Geometry(922, 102, 102, 102));
+
+        assertApplyGeometry("percent size",
+                            Geometry(10, 10, 100, 100), Geometry(0, 0, 50, 50),
+                            WIDTH_VALUE | HEIGHT_VALUE | WIDTH_PERCENT | HEIGHT_PERCENT,
+                            Geometry(0, 0, 500, 400),
+                            // expected
+                            Geometry(10, 10, 250, 200));
+
+        assertApplyGeometry("percent position",
+                            Geometry(0, 0, 100, 100), Geometry(10, 20, 0, 0),
+                            X_VALUE | Y_VALUE | X_PERCENT | Y_PERCENT,
+                            Geometry(0, 0, 500, 400),
+                            // expected
+                            Geometry(50, 80, 100, 100));
+    }
+
+    static void assertApplyGeometry(std::string msg,
+                                    Geometry gm, const Geometry &apply_gm, int mask,
+                                    const Geometry &screen_gm, const Geometry &e_gm) {
+        applyGeometry(gm, apply_gm, mask, screen_gm);
+        ASSERT_EQUAL("applyGeometry", msg + " x", e_gm.x, gm.x);
+        ASSERT_EQUAL("applyGeometry", msg + " y", e_gm.y, gm.y);
+        ASSERT_EQUAL("applyGeometry", msg + " width", e_gm.width, gm.width);
+        ASSERT_EQUAL("applyGeometry", msg + " height", e_gm.height, gm.height);
+    }
+};
+
+int
+main(int argc, char *argv[])
+{
+    try {
+        TestFrame::testApplyGeometry();
+        return 0;
+    } catch (AssertFailed &ex) {
+        std::cerr << ex.file() << ":" << ex.line() << " " << ex.msg() << std::endl;
+        return 1;
+    }
+}

--- a/test/test_x11.cc
+++ b/test/test_x11.cc
@@ -1,0 +1,77 @@
+//
+// test_x11.cc for pekwm
+// Copyright (C) 2020 Claes Nästén <pekdon@gmail.com>
+//
+// This program is licensed under the GNU GPL.
+// See the LICENSE file for more information.
+//
+
+#include <iostream>
+
+#include "test.hh"
+#include "x11.hh"
+
+class TestX11 : public X11 {
+public:
+    static void testParseGeometry(void) {
+        assertParseGeometry("short", "",
+                            Geometry(0, 0, 1, 1), 0);
+
+        assertParseGeometry("size", "10x20",
+                            Geometry(0, 0, 10, 20), WIDTH_VALUE | HEIGHT_VALUE);
+        assertParseGeometry("size prefix", "=20x30",
+                            Geometry(0, 0, 20, 30), WIDTH_VALUE | HEIGHT_VALUE);
+        assertParseGeometry("size", "30%x40%",
+                            Geometry(0, 0, 30, 40),
+                            WIDTH_VALUE | WIDTH_PERCENT | HEIGHT_VALUE | HEIGHT_PERCENT);
+        assertParseGeometry("position", "+30-40",
+                            Geometry(30, 40, 1, 1), X_VALUE | Y_VALUE | Y_NEGATIVE);
+        assertParseGeometry("position %", "+50%+60%",
+                            Geometry(50, 60, 1, 1),
+                            X_VALUE | X_PERCENT | Y_VALUE | Y_PERCENT);
+
+        assertParseGeometry("full", "=10%x200+300-20%",
+                            Geometry(300, 20, 10, 200),
+                            X_VALUE | Y_VALUE | WIDTH_VALUE | HEIGHT_VALUE |
+                            WIDTH_PERCENT | Y_NEGATIVE | Y_PERCENT);
+    }
+
+    static void assertParseGeometry(std::string msg, std::string str,
+                                    Geometry e_gm, int e_mask)
+    {
+        Geometry gm;
+        int mask = parseGeometry(str, gm);
+        ASSERT_EQUAL("parseGeometry", msg + " mask", e_mask, mask);
+        ASSERT_EQUAL("parseGeometry", msg + " x", e_gm.x, gm.x);
+        ASSERT_EQUAL("parseGeometry", msg + " y", e_gm.y, gm.y);
+        ASSERT_EQUAL("parseGeometry", msg + " width", e_gm.width, gm.width);
+        ASSERT_EQUAL("parseGeometry", msg + " height", e_gm.height, gm.height);
+    }
+
+    static void testParseGeometryVal(void) {
+        assertParseGeometryVal("invalid", "invalid", 0, 0);
+        assertParseGeometryVal("number", "1", 1, 1);
+        assertParseGeometryVal("percent", "10%", 2, 10);
+    }
+
+    static void assertParseGeometryVal(std::string msg, std::string str,
+                                       int e_ret, int e_val) {
+        int ret, val;
+        ret = parseGeometryVal(str.c_str(), str.c_str() + str.size(), val);
+        ASSERT_EQUAL("parseGeometryVal", msg + " ret", e_ret, ret);
+        ASSERT_EQUAL("parseGeometryVal", msg + " val", e_val, val);
+    }
+};
+
+int
+main(int argc, char *argv[])
+{
+    try {
+        TestX11::testParseGeometryVal();
+        TestX11::testParseGeometry();
+        return 0;
+    } catch (AssertFailed &ex) {
+        std::cerr << ex.file() << ":" << ex.line() << " " << ex.msg() << std::endl;
+        return 1;
+    }
+}


### PR DESCRIPTION
Support specifying geometry and position in perecentage of the screen/head
in functions that use X11 geometry format such as SetGeometry.

Configuration format:

SetGeometry 100%x50%+0+0 [(current|screen|head-number) [HonourStrut]]

Requested by okraits