### PR TITLE
Fix regression not updating client lists on new Frames (Closing #7)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 pekwm-0.2.0
 ===========
 
+Bug fixes
+---------
+
+* **#7 new windows fail to appear on fbpanel taskbar and pager**, regression introduced in 0.1.18.
+
 New
 ---
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -180,7 +180,6 @@ Frame::~Frame(void)
     _wo_map.erase(_window);
     woListRemove(this);
     _frames.erase(std::remove(_frames.begin(), _frames.end(), this), _frames.end());
-    Workspaces::remove(this);
     WindowManager::instance()->removeFromFrameList(this);
     if (_tag_frame == this) {
         _tag_frame = 0;
@@ -192,8 +191,7 @@ Frame::~Frame(void)
         delete _class_hint;
     }
 
-    Workspaces::updateClientList();
-    Workspaces::updateClientStackingList();
+    workspacesRemove();
 }
 
 // START - PWinObj interface.
@@ -500,9 +498,6 @@ Frame::activateChild(PWinObj *child)
     
     // Reload decor rules if needed.
     handleTitleChange(_client);
-
-    Workspaces::updateClientList();
-    Workspaces::updateClientStackingList();
 }
 
 /**
@@ -942,7 +937,7 @@ Frame::detachClient(Client *client)
         client->move(_gm.x, _gm.y + borderTop());
 
         Frame *frame = new Frame(client, 0);
-        Workspaces::insert(frame);
+        frame->workspacesInsert();
 
         client->setParent(frame);
         client->setWorkspace(Workspaces::getActive());
@@ -1084,12 +1079,10 @@ Frame::doGroupingDrag(XMotionEvent *ev, Client *client, bool behind) // FIXME: r
                 client->move(e.xmotion.x_root, e.xmotion.y_root);
 
                 Frame *frame = new Frame(client, 0);
-                Workspaces::insert(frame);
-
                 client->setParent(frame);
-
                 // make sure the client ends up on the current workspace
                 client->setWorkspace(Workspaces::getActive());
+                frame->workspacesInsert();
 
                 // make sure it get's focus
                 setFocused(false);
@@ -2414,4 +2407,26 @@ Frame::handleTitleChange(Client *client)
         // title or the name change did not cause the decor to change.
         renderTitle();
     }
+}
+
+/**
+ * Insert Frame into Workspaces and ensure client list is updated.
+ */
+void
+Frame::workspacesInsert()
+{
+    Workspaces::insert(this);
+    Workspaces::updateClientList();
+    Workspaces::updateClientStackingList();
+}
+
+/**
+ * Remove Frame from Workspaces and ensure client list is updated.
+ */
+void
+Frame::workspacesRemove()
+{
+    Workspaces::remove(this);
+    Workspaces::updateClientList();
+    Workspaces::updateClientStackingList();
 }

--- a/src/Frame.hh
+++ b/src/Frame.hh
@@ -186,7 +186,8 @@ private:
 
     void setupAPGeometry(Client *client, AutoProperty *ap);
 
-    void setActiveTitle(void);
+    void workspacesInsert();
+    void workspacesRemove();
 
     static uint findFrameID(void);
     static void returnFrameID(uint id);

--- a/src/WindowManager.cc
+++ b/src/WindowManager.cc
@@ -1439,6 +1439,8 @@ WindowManager::createClient(Window window, bool is_new)
         if (client->isAlive()) {
             if (initConfig.parent_is_new) {
                 Workspaces::insert(client->getParent(), true);
+                Workspaces::updateClientList();
+                Workspaces::updateClientStackingList();
             }
 
             // Make sure the window is mapped, this is done after it has been

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -73,3 +73,5 @@ set_target_properties(test_x11 PROPERTIES
   CXX_STANDARD_REQUIRED ON)
 target_include_directories(test_x11 PUBLIC ${common_INCLUDE_DIRS})
 target_link_libraries(test_x11 libpekwm ${common_LIBRARIES})
+
+add_subdirectory(system)

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(test_client test_client.cc)
+set_target_properties(test_client PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+target_include_directories(test_client PUBLIC ${X11_INCLUDE_DIR})
+target_link_libraries(test_client ${X11_LIBRARIES})
+
+add_executable(test_update_client_list test_update_client_list.cc)
+set_target_properties(test_update_client_list PROPERTIES
+  CXX_STANDARD 11
+  CXX_STANDARD_REQUIRED ON)
+target_include_directories(test_update_client_list PUBLIC ${X11_INCLUDE_DIR})
+target_link_libraries(test_update_client_list ${X11_LIBRARIES})

--- a/test/system/all.plux
+++ b/test/system/all.plux
@@ -15,11 +15,13 @@ in one go.
     !$BIN_DIR/pekwm --display $DISPLAY --config ./pekwm.config
     ?using configuration at ./pekwm.config
     ?failed to open file ./pekwm.config
+    !$_CTRL_C_
     ?SH-PROMPT:
 
     !env PEKWM_CONFIG_FILE=./pekwm.env.config $BIN_DIR/pekwm --display $DISPLAY
     ?using configuration at ./pekwm.env.config
     ?failed to open file ./pekwm.env.config
+    !$_CTRL_C_
     ?SH-PROMPT:
 
     # test without home set, supposed to fail
@@ -28,11 +30,45 @@ in one go.
     ?SH-PROMPT:
 [endfunction]
 
+[function test_update_client_list]
+    [shell test_update_client_list]
+        [log test_update_client_list]
+        ?SH-PROMPT:
+        !env DISPLAY=$DISPLAY $TEST_DIR/test_update_client_list
+        ?BEGIN WINDOWS
+        ?END WINDOWS
+        ?PROGRESS: wait for PropertyNotify
+
+    [shell test_client]
+        !env DISPLAY=$DISPLAY $TEST_DIR/test_client
+        ?Window ([0-9]+)
+        [global window=$1]
+        [log started test client $window]
+
+    [shell test_update_client_list]
+        ?BEGIN WINDOWS
+        ?Window $window
+        ?END WINDOWS
+        -Window $window
+
+    [shell test_client]
+        !$_CTRL_C_
+        ?SH-PROMPT:
+
+    [shell test_update_client_list]
+        ?BEGIN WINDOWS
+        ?END WINDOWS
+        -
+[endfunction]
+
 [shell Xvfb]
     [log starting Xvfb]
     !Xvfb -displayfd 1 $DISPLAY 2>/dev/null
     ?null
     ?1
+
+[shell test]
+    [call test_config_path]
 
 [shell pekwm]
     [log starting pekwm]
@@ -40,4 +76,4 @@ in one go.
     ?Enter event loop.
 
 [shell test]
-    [call test_config_path]
+    [call test_update_client_list]

--- a/test/system/test_client.cc
+++ b/test/system/test_client.cc
@@ -1,0 +1,47 @@
+/**
+ * Client used for testing pekwm.
+ */
+
+#include <iostream>
+
+extern "C" {
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+}
+
+
+int
+main(int argc, char *argv[])
+{
+    Display *dpy = XOpenDisplay(NULL);
+    if (dpy == NULL) {
+        std::cerr << "ERROR: unable to open display" << std::endl;
+        return 1;
+    }
+
+    int screen = DefaultScreen(dpy);
+    Window root = RootWindow(dpy, screen);
+
+    XSetWindowAttributes attrs = {0};
+    attrs.event_mask = PropertyChangeMask;
+    unsigned long attrs_mask = CWEventMask;
+
+    Window win = XCreateWindow(dpy, root,
+                               0, 0, 100, 100, 0,
+                               CopyFromParent, //depth
+                               InputOutput, // class
+                               CopyFromParent, // visual
+                               attrs_mask,
+                               &attrs);
+    XMapWindow(dpy, win);
+
+    std::cout << "Window " << win << std::endl;
+
+    XEvent ev;
+    while (! XNextEvent(dpy, &ev)) {
+    }
+
+    XCloseDisplay(dpy);
+
+    return 0;
+}

--- a/test/system/test_update_client_list.cc
+++ b/test/system/test_update_client_list.cc
@@ -1,0 +1,89 @@
+/**
+ * Test application for 
+ */
+
+#include <iostream>
+
+extern "C" {
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+}
+
+unsigned char*
+get_propery(Display *dpy, Window root, Atom atom,
+            unsigned long rread, unsigned long *nread, unsigned long *nleft)
+{
+    Atom real_type;
+    int real_format;
+    unsigned char *udata = 0;
+
+    XGetWindowProperty(dpy, root, atom,
+                       0L, rread, False, XA_WINDOW,
+                       &real_type, &real_format, nread, nleft, &udata);
+    if (rread == 0 && udata) {
+        XFree(udata);
+        udata = 0;
+    }
+
+    return udata;
+}
+
+void
+print_net_client_list(Display *dpy, Window root, Atom net_client_list)
+{
+    unsigned char *data;
+    unsigned long nread, nleft;
+
+    data = get_propery(dpy, root, net_client_list, 0L, &nread, &nleft);
+    nleft /= 4;
+
+    data = get_propery(dpy, root, net_client_list, nleft, &nread, &nleft);
+    Window *wins = reinterpret_cast<Window*>(data);
+    std::cout << "BEGIN WINDOWS" << std::endl;
+    for (int i = 0; i < nread; i++) {
+        std::cout << "  Window " << wins[i] << std::endl;
+    }
+    std::cout << "END WINDOWS" << std::endl;
+    XFree(data);
+}
+
+int
+main(int argc, char *argv[])
+{
+    Display *dpy = XOpenDisplay(NULL);
+    if (dpy == NULL) {
+        std::cerr << "ERROR: unable to open display" << std::endl;
+        return 1;
+    }
+
+    int screen = DefaultScreen(dpy);
+    Window root = RootWindow(dpy, screen);
+
+    // wait for property changes on the root window, will be sent
+    // whenever atoms get updated
+    XSelectInput(dpy, root, PropertyChangeMask);
+
+    // print initial window list
+    Atom net_client_list = XInternAtom(dpy, "_NET_CLIENT_LIST", False);
+    print_net_client_list(dpy, root, net_client_list);
+
+    // wait for property notify on window, then read the _NET_FRAME_EXTENTS
+    std::cout << "PROGRESS: wait for PropertyNotify" << std::endl;
+    XEvent ev;
+    while (! XNextEvent(dpy, &ev)) {
+        if (ev.type != PropertyNotify) {
+            std::cout << "ERROR: got event " << ev.type << std::endl;
+            exit(1);
+        }
+
+        XPropertyEvent *pev = &ev.xproperty;
+        if (pev->atom == net_client_list) {
+            std::cout << "PROGRESS: got event " << ev.type << std::endl;
+            print_net_client_list(dpy, root, net_client_list);
+        }
+    }
+
+    XCloseDisplay(dpy);
+
+    return 0;
+}


### PR DESCRIPTION
Regression introduced with the start of focus stealing prevention where
the client list was not updated when a new client was created.