### PR TITLE
Miscellaneous document updates

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -484,7 +484,7 @@ name (see [Custom Menus](configuration.md#custom-menus)):
 Bool is true for sticky menus, false for click to vanish. Defaults to
 false.
 
-** HideAllMenus**
+**HideAllMenus**
 
 Closes all pekwm menus.
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -132,7 +132,7 @@ a **$**, global variables with **$\_**.
 ```
 # examples of how to set both type of variables
 $INTERNAL = "this is an internal variable"
-$\_GLOBAL = "this is a global variable"
+$_GLOBAL = "this is a global variable"
 
 # examples of how to read both type of variables
 RootMenu = "Menu" {
@@ -291,7 +291,7 @@ all values should be placed inside quotes.
 |--------------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Workspaces                     | int             | Number of workspaces enabled.                                                                                                                                             |
 | WorkspacesPerRow               | int             | Number of workspaces on each row. Value < 1 fits all workspaces on a single row.                                                                                          |
-| WorkspaceNames                 | string          | List of names for workspaces separated by ;.                                                                                                                              |
+| WorkspaceNames                 | string          | List of names for workspaces separated by semicolon.                                                                                                                              |
 | ShowFrameList                  | boolean         | Controls whether a list of all available frames on the workspace is displayed during the NextFrame/PrevFrame actions.                                                     |
 | ShowStatusWindow               | boolean         | Controls whether a size/position info window is shown when moving or resizing windows.                                                                                    |
 | ShowStatusWindowCenteredOnRoot | boolean         | Controls whether a size/position info window is shown centered on the current head or the current window.                                                                 |
@@ -320,7 +320,7 @@ all values should be placed inside quotes.
 |---------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------|
 | TransientOnParent   | boolean | Set to true if you want the transient windows to be mappend on their "parent" window. |
 | Model               | string  | Default placement model, one of the below Placement Models.                                                                       |
-| WorkspacePlacements | string  | List of placement models for the workspaces separated by ;. For an explanation of the allowed options see "Model" above.          |
+| WorkspacePlacements | string  | List of placement models for the workspaces separated by semicolon. For an explanation of the allowed options see "Model" above.  |
 
 Placement Models:
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -155,13 +155,8 @@ the version (**/usr/local/bin/pekwm --version**).
 ### Can I turn off this sloppy focus crap?
 
 Yes. You can. You need to make all enter and leave events not affect
-the focus of frames, borders, clients. Simply, just comment out all
-the Enter lines that use the action Focus in _~/.pekwm/mouse_.
-
-The default _~/.pekwm/mouse_ configuration file has helpful "# Remove
-the following line if you want to use click to focus." notes in it to
-make this easier. Just search for such lines and remove or comment out
-the line (using a # in front of the line) next to the message.
+the focus of frames, borders, clients. See the comments above the
+`$CLIENT_CLICK = "Focus"` line in _~/.pekwm/mouse_.
 
 See [Mouse Bindings](actions.md#keys-and-mouse) for more info on the
 mouse configuration file.
@@ -386,5 +381,10 @@ Screen {
 ```
 
 ***
+
+### Mouse scrolling does not work with GTK3 applications?
+
+You need to set the environment variable `GDK_CORE_DEVICE_EVENTS` to
+1.
 
 [< Previous (Themes)](themes.md) - [(Development) Next >](development.md)


### PR DESCRIPTION
- a few markdown rendering fixes
- I replaced ; with semicolon because on my first reading I thought it
  was "separated by either semicolons or dots"
- the FAQ section about mouse configuration is outdated
- new FAQ section about GTK3 apps, quite many of them nowadays