### PR TITLE
Fix -Wsign-compare in X11.cc

### DIFF
--- a/src/x11.cc
+++ b/src/x11.cc
@@ -610,9 +610,7 @@ Geometry
 X11::getHeadGeometry(uint head)
 {
     Geometry gm(_screen_gm);
-    if (head > -1) {
-        getHeadInfo(head, gm);
-    }
+    getHeadInfo(head, gm);
     return gm;
 }
 


### PR DESCRIPTION
gcc-9.3.0 complains correctly that because 'head' is unsigned, the
comparison is always true. I've checked the caller and it seems all
negative numbers are already handled, so we should always get a good
positive number in here.