### PR TITLE
Cleanup in main.cc, introduce Util::getEnv

### DIFF
--- a/src/Completer.cc
+++ b/src/Completer.cc
@@ -122,7 +122,7 @@ public:
         _path_list.clear();
 
         vector<string> path_parts;
-        Util::splitString(getenv("PATH") ? getenv("PATH") : "", path_parts, ":");
+        Util::splitString(Util::getEnv("PATH"), path_parts, ":");
 
         vector<string>::iterator it(path_parts.begin());
         for (; it != path_parts.end(); ++it) {

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -37,7 +37,6 @@ using std::pair;
 using std::ifstream;
 using std::ofstream;
 using std::strtol;
-using std::getenv;
 
 Config* Config::_instance = 0;
 
@@ -471,8 +470,8 @@ Config::load(const std::string &config_file)
     }
 
     // Update PEKWM_CONFIG_FILE environment if needed (to reflect active file)
-    char *cfg_env = getenv("PEKWM_CONFIG_FILE");
-    if (! cfg_env || (strcmp(cfg_env, _config_file.c_str()) != 0)) {
+    auto cfg_env = Util::getEnv("PEKWM_CONFIG_FILE");
+    if (cfg_env.size() == 0 || _config_file.compare(cfg_env) != 0) {
         setenv("PEKWM_CONFIG_FILE", _config_file.c_str(), 1);
     }
 
@@ -1487,7 +1486,7 @@ Config::tryHardLoadConfig(CfgParser &cfg, std::string &file)
 
     // Try loading ~/.pekwm/config
     if (! success) {
-        file = string(getenv("HOME")) + string("/.pekwm/config");
+        file = Util::getEnv("HOME") + "/.pekwm/config";
         success = cfg.parse(file, CfgParserSource::SOURCE_FILE, true);
 
         // Copy cfg files to ~/.pekwm and try loading ~/.pekwm/config again.
@@ -1510,7 +1509,7 @@ Config::tryHardLoadConfig(CfgParser &cfg, std::string &file)
 void
 Config::copyConfigFiles(void)
 {
-    string cfg_dir = getenv("HOME") + string("/.pekwm");
+    string cfg_dir = Util::getEnv("HOME") + "/.pekwm";
 
     string cfg_file = cfg_dir + string("/config");
     string keys_file = cfg_dir + string("/keys");

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -78,6 +78,15 @@ const wchar_t *ICONV_WIDE_INVALID_STR = L"<INVALID>";
 // Constants, maximum number of bytes a single UTF-8 character can use.
 const size_t UTF8_MAX_BYTES = 6;
 
+/**
+ * Return environment variabel as string.
+ */
+std::string getEnv(const std::string& key)
+{
+    auto val = getenv(key.c_str());
+    return val ? val : "";
+}
+
 //! @brief Fork and execute command with /bin/sh and execlp
 void
 forkExec(std::string command)
@@ -267,7 +276,7 @@ expandFileName(std::string &file)
 {
     if (file.size() > 0) {
         if (file[0] == '~') {
-            file.replace(0, 1, getenv("HOME"));
+            file.replace(0, 1, getEnv("HOME"));
         }
     }
 }

--- a/src/Util.hh
+++ b/src/Util.hh
@@ -39,6 +39,8 @@ namespace String {
 
 //! @brief Namespace Util used for various small file/string tasks.
 namespace Util {
+    std::string getEnv(const std::string& key);
+
     void forkExec(std::string command);
     std::string getHostname(void);
 

--- a/src/WindowManager.cc
+++ b/src/WindowManager.cc
@@ -291,7 +291,7 @@ WindowManager::setupDisplay(bool replace)
     if (! dpy) {
         cerr << "Can not open display!" << endl
              << "Your DISPLAY variable currently is set to: "
-             << getenv("DISPLAY") << endl;
+             << Util::getEnv("DISPLAY") << endl;
         exit(1);
     }
 

--- a/test/system/all.plux
+++ b/test/system/all.plux
@@ -1,0 +1,43 @@
+[doc]
+Run system tests using Xvfb
+
+Start a single Xvfb and pekwm session and run all pekwm system tests
+in one go.
+[enddoc]
+
+[global BIN_DIR=../../build/src]
+[global TEST_DIR=../../build/test/system]
+[global DISPLAY=:1]
+
+# test possible ways of setting the configuration file used by pekwm
+[function test_config_path]
+    [log test_config_path]
+    !$BIN_DIR/pekwm --display $DISPLAY --config ./pekwm.config
+    ?using configuration at ./pekwm.config
+    ?failed to open file ./pekwm.config
+    ?SH-PROMPT:
+
+    !env PEKWM_CONFIG_FILE=./pekwm.env.config $BIN_DIR/pekwm --display $DISPLAY
+    ?using configuration at ./pekwm.env.config
+    ?failed to open file ./pekwm.env.config
+    ?SH-PROMPT:
+
+    # test without home set, supposed to fail
+    !env -i $BIN_DIR/pekwm --display $DISPLAY
+    ???failed to get configuration file path, $HOME not set.
+    ?SH-PROMPT:
+[endfunction]
+
+[shell Xvfb]
+    [log starting Xvfb]
+    !Xvfb -displayfd 1 $DISPLAY 2>/dev/null
+    ?null
+    ?1
+
+[shell pekwm]
+    [log starting pekwm]
+    !$BIN_DIR/pekwm --display $DISPLAY
+    ?Enter event loop.
+
+[shell test]
+    [call test_config_path]


### PR DESCRIPTION
Wrap getenv in Util to return a std::string for simpler (and less
dangerous) code.