### PR TITLE
Bump minimum required CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMake/Modules/")
 include(CheckSymbolExists)

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,3 +1,3 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(lobo)

--- a/contrib/lobo/CMakeLists.txt
+++ b/contrib/lobo/CMakeLists.txt
@@ -1,1 +1,1 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(themes)
 add_subdirectory(scripts)

--- a/data/scripts/CMakeLists.txt
+++ b/data/scripts/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pekwm_themeset.sh.in
   ${CMAKE_CURRENT_BINARY_DIR}/pekwm_themeset.sh @ONLY)

--- a/data/themes/CMakeLists.txt
+++ b/data/themes/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(default)
 add_subdirectory(default-plain)

--- a/data/themes/default-plain/CMakeLists.txt
+++ b/data/themes/default-plain/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 install(FILES
   theme

--- a/data/themes/default/CMakeLists.txt
+++ b/data/themes/default/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 file(GLOB default_png_files "${CMAKE_CURRENT_SOURCE_DIR}/*.png")
 

--- a/data/themes/pion/CMakeLists.txt
+++ b/data/themes/pion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 install(FILES
   theme

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 install(FILES
   pekwm.1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
CMake < 2.8.12 support has been deprecated in recent CMake versions.
Judging from the CMake site 3.5 should be a safe version to get support
from most recent Linux distributions.

Thanks biopsin for reporting. Closing #28