### PR TITLE
Don't keep path cache around for the CmdDialog, refresh on map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@ New
 Updated
 -------
 
+**CmdDialog** no longer cache the list of available commands reducing
+memory consumption and speeding up start at the cost of slower mapping
+of the CmdDialog.
+
 **SetGeometry** now support specifying size and position in % of the
 screen or active head.
 

--- a/src/CmdDialog.cc
+++ b/src/CmdDialog.cc
@@ -91,7 +91,19 @@ CmdDialog::exec(void)
     return &_ae;
 }
 
-//! @brief Unmaps window, overloaded to clear buffer.
+/**
+ * Map window, overloaded to refresh completions.
+ */
+void
+CmdDialog::mapWindow(void)
+{
+    InputDialog::mapWindow();
+    _completer.refresh();
+}
+
+/**
+ * Unmaps window, overloaded to clear buffer and unset reference.
+ */
 void
 CmdDialog::unmapWindow(void)
 {
@@ -99,6 +111,7 @@ CmdDialog::unmapWindow(void)
         InputDialog::unmapWindow();
         setWORef(0);
         bufClear();
+        _completer.clear();
     }
 }
 

--- a/src/CmdDialog.hh
+++ b/src/CmdDialog.hh
@@ -26,6 +26,9 @@ public:
     CmdDialog(Theme *theme);
     virtual ~CmdDialog(void);
 
+    // BEGIN - PWinObj interface
+    virtual void mapWindow(void);
+    // END - PWinObj interface
     void unmapWindow(void);
 
     virtual void mapCentered(const std::string &buf, const Geometry &geom, PWinObj *wo_ref);

--- a/src/Completer.cc
+++ b/src/Completer.cc
@@ -70,6 +70,8 @@ public:
     virtual unsigned int complete(CompletionState &completion_state) { return 0; }
     /** Refresh completion list. */
     virtual void refresh(void)=0;
+    /** Clear completion list. */
+    virtual void clear(void)=0;
 
 protected:
     /**
@@ -118,8 +120,7 @@ public:
     }
 
     void refresh(void) {
-        // Clear out previous data
-        _path_list.clear();
+        clear();
 
         vector<string> path_parts;
         Util::splitString(Util::getEnv("PATH"), path_parts, ":");
@@ -135,6 +136,10 @@ public:
 
         std::unique(_path_list.begin(), _path_list.end());
         std::sort(_path_list.begin(), _path_list.end());
+    }
+
+    void clear(void) {
+        _path_list.clear();
     }
 
 private:
@@ -225,6 +230,8 @@ public:
         completions_list_from_name_list(MenuHandler::getMenuNames(), _menu_list);
     }
 
+    void clear(void) { }
+
 private:
     State find_state(CompletionState &completion_state);
     size_t find_state_word_start(const std::wstring &str);
@@ -269,6 +276,24 @@ Completer::~Completer(void)
 {
     delete _completer_action;
     delete _completer_path;
+}
+
+/**
+ * Refresh completions.
+ */
+void
+Completer::refresh()
+{
+    _completer_path->refresh();
+}
+
+/**
+ * Clear data used by completions.
+ */
+void
+Completer::clear()
+{
+    _completer_path->clear();
 }
 
 /**

--- a/src/Completer.hh
+++ b/src/Completer.hh
@@ -48,6 +48,9 @@ public:
     /** Completer destructor. */
     ~Completer(void);
 
+    void refresh();
+    void clear();
+
     complete_list find_completions(const std::wstring &str, unsigned int pos);
     std::wstring do_complete(const std::wstring &str, unsigned int &pos,
                              complete_list &completions, complete_it &it);


### PR DESCRIPTION
Speed up startup, use less memory at the expense of slower CmdDialog
displaying by not building the CmdDialog cache for paths on startup.

Build it on map effectively keeping an up-to-date list of available
commands and clear the list when it is unmapped.