### PR TITLE
Move more resources out of WindowManager

### DIFF
--- a/src/ActionHandler.cc
+++ b/src/ActionHandler.cc
@@ -135,7 +135,8 @@ ActionHandler::handleAction(const ActionPerformed &ap)
                 client->kill();
                 break;
             case ACTION_SET_GEOMETRY:
-                frame->setGeometry(it->getParamS(), it->getParamI(0), it->getParamI(1) == 1);
+                frame->setGeometry(it->getParamS(),
+                                   it->getParamI(0), it->getParamI(1) == 1);
                 break;
             case ACTION_RAISE:
                 if (it->getParamI(0)) {
@@ -308,7 +309,9 @@ ActionHandler::handleAction(const ActionPerformed &ap)
                 // Events caused by a motion event ( dragging frame to
                 // the edge ) or enter event ( moving the pointer to
                 // the edge ) should warp the pointer.
-                actionGotoWorkspace(it->getParamI(0), (ap.type == MotionNotify) || (ap.type == EnterNotify));
+                actionGotoWorkspace(it->getParamI(0),
+                                    (ap.type == MotionNotify)
+                                    || (ap.type == EnterNotify));
                 break;
             case ACTION_FIND_CLIENT:
                 actionFindClient(Util::to_wide_str(it->getParamS()));
@@ -340,10 +343,12 @@ ActionHandler::handleAction(const ActionPerformed &ap)
                 _wm->shutdown();
                 break;
             case ACTION_SHOW_CMD_DIALOG:
-                actionShowInputDialog(_wm->getCmdDialog(), it->getParamS(), frame, wo);
+                actionShowInputDialog(&_cmd_dialog, it->getParamS(),
+                                      frame, wo);
                 break;
             case ACTION_SHOW_SEARCH_DIALOG:
-                actionShowInputDialog(_wm->getSearchDialog(), it->getParamS(), frame, wo);
+                actionShowInputDialog(&_search_dialog, it->getParamS(),
+                                      frame, wo);
                 break;
             case ACTION_DEBUG:
 #ifdef DEBUG
@@ -473,7 +478,7 @@ ActionHandler::handleStateAction(const Action &action, PWinObj *wo,
         matched = true;
         switch (action.getParamI(0)) {
         case ACTION_STATE_HARBOUR_HIDDEN:
-            _wm->getHarbour()->setStateHidden(sa);
+            pekwm::harbour()->setStateHidden(sa);
             break;
         case ACTION_STATE_GLOBAL_GROUPING:
             ClientMgr::setStateGlobalGrouping(sa);

--- a/src/ActionHandler.hh
+++ b/src/ActionHandler.hh
@@ -13,7 +13,8 @@
 
 #include "pekwm.hh"
 #include "Action.hh"
-#include "InputDialog.hh"
+#include "CmdDialog.hh"
+#include "SearchDialog.hh"
 
 #include <string>
 #include <map>
@@ -23,6 +24,8 @@ class Frame;
 class PWinObj;
 class PDecor;
 class PMenu;
+class CmdDialog;
+class SearchDialog;
 class WindowManager;
 
 class ActionHandler
@@ -68,6 +71,8 @@ private:
 
 private:
     WindowManager *_wm;
+    CmdDialog _cmd_dialog;
+    SearchDialog _search_dialog;
 
     /** Map translating state modifiers to keycode. */
     std::map<uint, uint> _state_to_keycode;

--- a/src/Client.cc
+++ b/src/Client.cc
@@ -39,6 +39,7 @@ extern "C" {
 #include "Workspaces.hh"
 #include "PImageIcon.hh"
 #include "TextureHandler.hh"
+#include "ManagerWindows.hh"
 
 const long Client::_clientEventMask = \
     PropertyChangeMask|StructureNotifyMask|FocusChangeMask|KeyPressMask;
@@ -1873,9 +1874,8 @@ Client::getStrutHint(void)
         _strut = new Strut();
         *_strut = strut;
         XFree(strut);
-        
         if (! isCfgDeny(CFG_DENY_STRUT)) {
-            X11::addStrut(_strut);
+            pekwm::rootWo()->addStrut(_strut);
         }
     }
 }
@@ -1889,7 +1889,7 @@ Client::removeStrutHint(void)
 {
     if ( _strut) {
         if (! isCfgDeny(CFG_DENY_STRUT)) {
-            X11::removeStrut(_strut);
+            pekwm::rootWo()->removeStrut(_strut);
         }
         delete _strut;
         _strut = 0;

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -29,6 +29,7 @@ extern "C" {
 #include "AutoProperties.hh"
 #include "Client.hh"
 #include "ClientMgr.hh"
+#include "ManagerWindows.hh"
 #include "StatusWindow.hh"
 #include "Workspaces.hh"
 #include "KeyGrabber.hh"
@@ -942,10 +943,11 @@ bool
 Frame::fixGeometry(void)
 {
     Geometry head, before;
-    if (_fullscreen)
+    if (_fullscreen) {
         X11::getHeadInfo(getNearestHead(), head);
-    else
-        X11::getHeadInfoWithEdge(getNearestHead(), head);
+    } else {
+        pekwm::rootWo()->getHeadInfoWithEdge(getNearestHead(), head);
+    }
 
     before = _gm;
 
@@ -1329,8 +1331,8 @@ Frame::moveToHead(int head_nr)
     }
 
     Geometry old_gm, new_gm;
-    X11::getHeadInfoWithEdge(curr_head_nr, old_gm);
-    X11::getHeadInfoWithEdge(head_nr, new_gm);
+    pekwm::rootWo()->getHeadInfoWithEdge(curr_head_nr, old_gm);
+    pekwm::rootWo()->getHeadInfoWithEdge(head_nr, new_gm);
 
     // Ensure the window fits in the new head.
     _gm.x = new_gm.x + (_gm.x - old_gm.x);
@@ -1357,7 +1359,7 @@ Frame::moveToEdge(OrientationType ori)
 
     head_nr = getNearestHead();
     X11::getHeadInfo(head_nr, real_head);
-    X11::getHeadInfoWithEdge(head_nr, head);
+    pekwm::rootWo()->getHeadInfoWithEdge(head_nr, head);
 
     switch (ori) {
     case TOP_LEFT:
@@ -1451,7 +1453,7 @@ Frame::setStateMaximized(StateAction sa, bool horz, bool vert, bool fill)
     XSizeHints *size_hint = _client->getXSizeHints(); // convenience
 
     Geometry head;
-    X11::getHeadInfoWithEdge(getNearestHead(), head);
+    pekwm::rootWo()->getHeadInfoWithEdge(getNearestHead(), head);
 
     int max_x, max_r, max_y, max_b;
     max_x = head.x;
@@ -1817,7 +1819,7 @@ Frame::setGeometry(const std::string geometry, int head, bool honour_strut)
         }
 
         if (honour_strut) {
-            X11::getHeadInfoWithEdge(head, screen_gm);
+            pekwm::rootWo()->getHeadInfoWithEdge(head, screen_gm);
         } else {
             screen_gm = X11::getHeadGeometry(head);
         }
@@ -1842,7 +1844,7 @@ void
 Frame::growDirection(uint direction)
 {
     Geometry head;
-    X11::getHeadInfoWithEdge(getNearestHead(), head);
+    pekwm::rootWo()->getHeadInfoWithEdge(getNearestHead(), head);
 
     switch (direction) {
     case DIRECTION_UP:

--- a/src/Harbour.hh
+++ b/src/Harbour.hh
@@ -13,7 +13,10 @@
 
 #include "pekwm.hh"
 
+class AutoProperties;
+class Config;
 class DockApp;
+class RootWO;
 class Strut;
 
 #include "Action.hh"
@@ -21,7 +24,7 @@ class Strut;
 class Harbour
 {
 public:
-    Harbour(void);
+    Harbour(Config* cfg, AutoProperties* ap, RootWO *root_wo);
     ~Harbour(void);
 
     void addDockApp(DockApp* da);
@@ -58,11 +61,21 @@ private:
 
     void updateStrutSize(void);
 
+private:
+    Config* _cfg;
+    AutoProperties* _ap;
+    RootWO *_root_wo;
+
     std::vector<DockApp*> _dapps;
     bool _hidden;
     uint _size;
     Strut *_strut;
     int _last_button_x, _last_button_y;
+};
+
+namespace pekwm
+{
+    Harbour* harbour();
 };
 
 #endif // _HARBOUR_HH_

--- a/src/ManagerWindows.hh
+++ b/src/ManagerWindows.hh
@@ -23,12 +23,13 @@
 class HintWO : public PWinObj
 {
 public:
-    HintWO(Window root, bool replace);
+    HintWO(Window root);
     virtual ~HintWO(void);
+
+    bool claimDisplay(bool replace);
 
 private:
     Time getTime(void);
-    bool claimDisplay(bool replace);
     bool claimDisplayWait(Window session_owner);
     void claimDisplayOwner(Window session_atom, Time timestamp);
 
@@ -62,6 +63,15 @@ public:
     virtual ActionEvent *handleEnterEvent(XCrossingEvent *ev);
     virtual ActionEvent *handleLeaveEvent(XCrossingEvent *ev);
 
+    void placeInsideScreen(Geometry &gm, bool without_edge=false);
+    void getHeadInfoWithEdge(uint num, Geometry& head);
+
+    void updateGeometry(uint width, uint height);
+    void addStrut(Strut *strut);
+    void removeStrut(Strut *rem_strut);
+    void updateStrut(void);
+    const Strut& getStrut(void) { return _strut; }
+
     void setEwmhWorkarea(const Geometry &workarea);
     void setEwmhActiveWindow(Window win);
     void readEwmhDesktopNames(void);
@@ -69,7 +79,14 @@ public:
     void setEwmhDesktopLayout(void);
 
 private:
+    void initStrutHead();
+
+private:
     HintWO *_hint_wo;
+
+    Strut _strut;
+    std::vector<Strut> _strut_head;
+    std::vector<Strut*> _struts;
 
     /** Root window event mask. */
     static const unsigned long EVENT_MASK;
@@ -84,7 +101,7 @@ private:
 class EdgeWO : public PWinObj
 {
 public:
-    EdgeWO(Window root, EdgeType edge, bool set_strut);
+    EdgeWO(RootWO *root_wo, EdgeType edge, bool set_strut);
     virtual ~EdgeWO(void);
 
     void configureStrut(bool set_strut);
@@ -98,8 +115,15 @@ public:
     inline EdgeType getEdge(void) const { return _edge; }
 
 private:
+    RootWO* _root_wo;
     EdgeType _edge; /**< Edge position. */
     Strut _strut; /*< Strut for reserving screen edge space. */
 };
+
+namespace pekwm
+{
+    HintWO* hintWo();
+    RootWO* rootWo();
+}
 
 #endif // _MANAGER_WINDOWS_H_

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -26,6 +26,7 @@ extern "C" {
 #include "PTexture.hh"
 #include "PTexturePlain.hh" // PTextureSolid
 #include "ActionHandler.hh"
+#include "ManagerWindows.hh"
 #include "StatusWindow.hh"
 #include "KeyGrabber.hh"
 #include "Theme.hh"
@@ -1720,7 +1721,8 @@ PDecor::checkEdgeSnap(void)
     int resist = pekwm::config()->getEdgeResist();
 
     Geometry head;
-    X11::getHeadInfoWithEdge(X11::getNearestHead(_gm.x, _gm.y), head);
+    pekwm::rootWo()->getHeadInfoWithEdge(X11::getNearestHead(_gm.x, _gm.y),
+                                         head);
 
     if ((_gm.x >= (head.x - resist)) && (_gm.x <= (head.x + attract))) {
         _gm.x = head.x;

--- a/src/WinLayouter.cc
+++ b/src/WinLayouter.cc
@@ -12,6 +12,7 @@
 #include "Client.hh"
 #include "Frame.hh"
 #include "Util.hh"
+#include "ManagerWindows.hh"
 #include "Workspaces.hh"
 #include "x11.hh"
 
@@ -201,7 +202,7 @@ private:
                         wo->getWidth(), wo->getHeight());
 
             // make sure it's within the screen's border
-            X11::placeInsideScreen(gm);
+            pekwm::rootWo()->placeInsideScreen(gm);
             wo->move(gm.x, gm.y);
         }
         return true;
@@ -218,7 +219,7 @@ private:
     {
         if (wo) {
             Geometry gm(_ptr_x, _ptr_y, wo->getWidth(), wo->getHeight());
-            X11::placeInsideScreen(gm); // make sure it's within the screen's border
+            pekwm::rootWo()->placeInsideScreen(gm);
             wo->move(gm.x, gm.y);
         }
         return true;
@@ -240,7 +241,7 @@ WinLayouter::layout(Frame *frame, Window parent)
 
     X11::getMousePosition(_ptr_x, _ptr_y);
     int head_nr = X11::getNearestHead(_ptr_x, _ptr_y);
-    X11::getHeadInfoWithEdge(head_nr, _gm);
+    pekwm::rootWo()->getHeadInfoWithEdge(head_nr, _gm);
 
     // Collect the information which head has a fullscreen window.
     // To be conservative for now we ignore fullscreen windows on
@@ -263,7 +264,7 @@ WinLayouter::layout(Frame *frame, Window parent)
     int i = head_nr;
     do {
         if (! fsHead[i]) {
-            X11::getHeadInfoWithEdge(i, _gm);
+            pekwm::rootWo()->getHeadInfoWithEdge(i, _gm);
             if (layout_impl(frame)) {
                 return;
             }
@@ -280,7 +281,7 @@ WinLayouter::layout(Frame *frame, Window parent)
         }
         i = (i+1)%X11::getNumHeads();
     } while (i != head_nr);
-    X11::getHeadInfoWithEdge(i, _gm);
+    pekwm::rootWo()->getHeadInfoWithEdge(i, _gm);
     frame->move(_gm.x, _gm.y);
 }
 

--- a/src/WindowManager.hh
+++ b/src/WindowManager.hh
@@ -57,9 +57,6 @@ public:
     //! @brief Sets shutdown status, will shutdown from main loop.
     void shutdown(void) { _shutdown = true; }
 
-    // get "base" classes
-    inline Harbour *getHarbour(void) const { return _harbour; }
-
     inline bool shallRestart(void) const { return _restart; }
     inline const std::string &getRestartCommand(void) const {
         return _restart_command;
@@ -74,9 +71,6 @@ public:
     Frame* getPrevFrame(Frame* frame, bool mapped, uint mask = 0);
 
     void findWOAndFocus(PWinObj *wo);
-
-    inline CmdDialog *getCmdDialog(void) { return _cmd_dialog; }
-    inline SearchDialog *getSearchDialog(void) { return _search_dialog; }
 
     // public event handlers used when doing grabbed actions
     void handleKeyEvent(XKeyEvent *ev);
@@ -133,18 +127,12 @@ private:
     Client *createClient(Window window, bool is_new);
 
 private:
-    Harbour *_harbour;
-    CmdDialog *_cmd_dialog;
-    SearchDialog *_search_dialog;
-
     bool _shutdown; //!< Set to wheter we want to shutdown.
     bool _reload; //!< Set to wheter we want to reload.
     bool _restart;
     std::string _restart_command;
 
     EdgeWO *_screen_edges[4];
-    HintWO *_hint_wo; /**< Hint window object, communicates EWMH hints. */
-    RootWO *_root_wo; /**< Root window object, wrapper for root window. */
 };
 
 #endif // _WINDOWMANAGER_HH_

--- a/src/Workspaces.cc
+++ b/src/Workspaces.cc
@@ -16,6 +16,7 @@
 #include "PDecor.hh"
 #include "Frame.hh"
 #include "Client.hh" // For isSkip()
+#include "ManagerWindows.hh"
 #include "WinLayouter.hh"
 #include "WorkspaceIndicator.hh"
 #include "x11.hh"
@@ -694,7 +695,7 @@ Workspaces::placeWoInsideScreen(PWinObj *wo)
         }
     }
 
-    X11::placeInsideScreen(gm_after, strut);
+    pekwm::rootWo()->placeInsideScreen(gm_after, strut);
     if (gm_before != gm_after) {
         wo->move(gm_after.x, gm_after.y);
     }

--- a/src/pekwm.cc
+++ b/src/pekwm.cc
@@ -12,7 +12,9 @@
 #include "AutoProperties.hh"
 #include "Config.hh"
 #include "FontHandler.hh"
+#include "Harbour.hh"
 #include "ImageHandler.hh"
+#include "ManagerWindows.hh"
 #include "KeyGrabber.hh"
 #include "StatusWindow.hh"
 #include "TextureHandler.hh"
@@ -24,8 +26,11 @@ static ActionHandler* _action_handler = nullptr;
 static AutoProperties* _auto_properties = nullptr;
 static Config* _config = nullptr;
 static FontHandler* _font_handler = nullptr;
+static Harbour* _harbour = nullptr;
+static HintWO* _hint_wo = nullptr;
 static ImageHandler* _image_handler = nullptr;
 static KeyGrabber* _key_grabber = nullptr;
+static RootWO* _root_wo = nullptr;
 static StatusWindow* _status_window = nullptr;
 static TextureHandler* _texture_handler = nullptr;
 static Theme* _theme = nullptr;
@@ -40,6 +45,11 @@ namespace pekwm
 
         X11::init(dpy, _config->isHonourRandr());
 
+        _hint_wo = new HintWO(X11::getRoot());
+        // Create root PWinObj
+        _root_wo = new RootWO(X11::getRoot(), _hint_wo);
+        PWinObj::setRootPWinObj(_root_wo);
+
         _auto_properties = new AutoProperties();
         _auto_properties->load();
         _key_grabber = new KeyGrabber();
@@ -51,6 +61,7 @@ namespace pekwm
         _texture_handler = new TextureHandler();
         _theme = new Theme(_font_handler, _image_handler, _texture_handler);
 
+        _harbour = new Harbour(_config, _auto_properties, _root_wo);
         _status_window = new StatusWindow(_theme);
 
         _action_handler = new ActionHandler(wm);
@@ -59,6 +70,7 @@ namespace pekwm
     void cleanup()
     {
         delete _action_handler;
+        delete _harbour;
         delete _status_window;
         delete _theme;
         delete _texture_handler;
@@ -66,6 +78,10 @@ namespace pekwm
         delete _font_handler;
         delete _key_grabber;
         delete _auto_properties;
+
+        delete _root_wo;
+        PWinObj::setRootPWinObj(nullptr);
+        delete _hint_wo;
 
         X11::destruct();
 
@@ -90,6 +106,21 @@ namespace pekwm
     FontHandler* fontHandler()
     {
         return _font_handler;
+    }
+
+    Harbour* harbour()
+    {
+        return _harbour;
+    }
+
+    HintWO* hintWo()
+    {
+        return _hint_wo;
+    }
+
+    RootWO* rootWo()
+    {
+        return _root_wo;
     }
 
     ImageHandler* imageHandler()

--- a/src/x11.hh
+++ b/src/x11.hh
@@ -95,14 +95,13 @@ public:
     int y;
     uint width;
     uint height;
-
-    Strut strut;
 };
 
 //! @brief Display information class.
 class X11
 {
-    //! Bits 1-15 are modifier masks, but bits 13 and 14 aren't named in X11/X.h.
+    /** Bits 1-15 are modifier masks, but bits 13 and 14 aren't
+        named in X11/X.h. */
     static const unsigned KbdLayoutMask1 = 1<<13;
     static const unsigned KbdLayoutMask2 = 1<<14;
 
@@ -152,7 +151,7 @@ public:
     inline static bool hasExtensionShape(void) { return _has_extension_shape; }
     inline static int getEventShape(void) { return _event_shape; }
 
-    static void updateGeometry(uint width, uint height);
+    static bool updateGeometry(uint width, uint height);
 
     inline static bool hasExtensionXRandr(void) { return _has_extension_xrandr; }
     inline static int getEventXRandr(void) { return _event_xrandr; }
@@ -171,7 +170,6 @@ public:
     static uint getCurrHead(void);
     static bool getHeadInfo(uint head, Geometry &head_info);
     static Geometry getHeadGeometry(uint head);
-    static void getHeadInfoWithEdge(uint head, Geometry &head_info);
     inline static int getNumHeads(void) { return _heads.size(); }
 
     inline static Time getLastEventTime(void) { return _last_event_time; }
@@ -286,11 +284,6 @@ public:
     static void getMousePosition(int &x, int &y);
     static uint getButtonFromState(uint state);
 
-    static void addStrut(Strut *strut);
-    static void removeStrut(Strut *rem_strut);
-    static void updateStrut(void);
-    inline static Strut *getStrut(void) { return &_strut; }
-
     static uint getMaskFromKeycode(KeyCode keycode);
     static KeyCode getKeycodeFromMask(uint mask);
     static KeySym getKeysymFromKeycode(KeyCode keycode);
@@ -322,32 +315,6 @@ public:
         }
         if (gm.y + static_cast<int>(gm.height) < 3) {
             gm.y = 3 - gm.height;
-        }
-    }
-
-    //! @brief Makes sure the Geometry is inside the screen.
-    static
-    void placeInsideScreen(Geometry &gm, bool withoutedge=false) {
-        uint head_nr = getNearestHead(gm.x, gm.y);
-        Geometry head;
-        if (withoutedge) {
-            getHeadInfo(head_nr, head);
-        } else {
-            getHeadInfoWithEdge(head_nr, head);
-        }
-
-        if (gm.x + gm.width > head.x + head.width) {
-            gm.x = head.x + head.width - gm.width;
-        }
-        if (gm.x < head.x) {
-            gm.x = head.x;
-        }
-
-        if (gm.y + gm.height > head.y + head.height) {
-            gm.y = head.y + head.height - gm.height;
-        }
-        if (gm.y < head.y) {
-            gm.y = head.y;
         }
     }
 
@@ -510,9 +477,6 @@ private:
     // information for dobule clicks
     static Window _last_click_id;
     static Time _last_click_time[BUTTON_NO - 1];
-
-    static Strut _strut;
-    static std::vector<Strut*> _struts;
 
     static std::array<Cursor, MAX_NR_CURSOR> _cursor_map;
 


### PR DESCRIPTION
Move Harbour, CmdDialog, SearchDialog, HintWO and RootWO from
WindowManager into the pekwm namespace and ActionHandler.

While at it, moved Strut information out from namespace x11 and into
RootWO.