### PR TITLE
Move resize in percentage

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -507,27 +507,32 @@ MoveResize
 **MoveHorizontal (int)**
 
 Moves a frame horizontally. Int is amount of pixels and can be
-negative.
+negative. Int can be followed by '%' which denotes the percent of the
+screen width.
 
 > Moveresize-specific keybinding
 
 **MoveVertical (int)**
 
-Moves a frame vertically. Int is amount of pixels and can be negative.
+Moves a frame vertically. Int is amount of pixels and can be
+negative. Int can be followed by '%' which denotes the percent of the
+screen height.
 
 >Moveresize-specific keybinding
 
 **ResizeHorizontal (int)**
 
 Resizes a frame horizontally. Int is amount of pixels and can be
-negative.
+negative. Int can be followed by '%' which denotes the percent of the
+screen width.
 
 >Moveresize-specific keybinding
 
 **ResizeVertical (int)**
 
 Resizes a frame vertically. Int is amount of pixels and can be
-negative.
+negative. Int can be followed by '%' which denotes the percent of the
+screen height.
 
 >Moveresize-specific keybinding
 

--- a/src/Action.hh
+++ b/src/Action.hh
@@ -143,6 +143,12 @@ enum InputDialogAction {
     INPUT_NO_ACTION
 };
 
+enum ActionParamUnit {
+    UNIT_NONE,
+    UNIT_PIXEL,
+    UNIT_PERCENT
+};
+
 // Action Utils
 namespace ActionUtil {
     //! @brief Determines if state needs toggling.

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -752,9 +752,9 @@ Config::parseMoveResizeAction(const std::string &action_string, Action &action)
                 case MOVE_VERTICAL:
                 case RESIZE_HORIZONTAL:
                 case RESIZE_VERTICAL:
-                case MOVE_SNAP:
                     action.setParamI(0, strtol(tok[1].c_str(), 0, 10));
                     break;
+                case MOVE_SNAP:
                 default:
                     // Do nothing.
                     break;

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -751,9 +751,16 @@ Config::parseMoveResizeAction(const std::string &action_string, Action &action)
                 case MOVE_HORIZONTAL:
                 case MOVE_VERTICAL:
                 case RESIZE_HORIZONTAL:
-                case RESIZE_VERTICAL:
-                    action.setParamI(0, strtol(tok[1].c_str(), 0, 10));
+                case RESIZE_VERTICAL: {
+                    char *endptr = nullptr;
+                    action.setParamI(0, strtol(tok[1].c_str(), &endptr, 10));
+                    if (endptr && *endptr == '%') {
+                        action.setParamI(1, UNIT_PERCENT);
+                    } else {
+                        action.setParamI(1, UNIT_PIXEL);
+                    }
                     break;
+                }
                 case MOVE_SNAP:
                 default:
                     // Do nothing.

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -1339,25 +1339,49 @@ PDecor::doKeyboardMoveResize(void)
             for (; it != ae->action_list.end(); ++it) {
                 switch (it->getAction()) {
                 case MOVE_HORIZONTAL:
-                    _gm.x += it->getParamI(0);
+                    if (it->getParamI(1) == UNIT_PERCENT) {
+                        Geometry head;
+                        X11::getHeadInfo(X11::getCurrHead(), head);
+                        _gm.x += (it->getParamI(0) * static_cast<int>(head.width)) / 100;
+                    } else {
+                        _gm.x += it->getParamI(0);
+                    }
                     if (! outline) {
                         move(_gm.x, _gm.y);
                     }
                     break;
                 case MOVE_VERTICAL:
-                    _gm.y += it->getParamI(0);
+                    if (it->getParamI(1) == UNIT_PERCENT) {
+                        Geometry head;
+                        X11::getHeadInfo(X11::getCurrHead(), head);
+                        _gm.y += (it->getParamI(0) * static_cast<int>(head.height)) / 100;
+                    } else {
+                        _gm.y +=  it->getParamI(0);
+                    }
                     if (! outline) {
                         move(_gm.x, _gm.y);
                     }
                     break;
                 case RESIZE_HORIZONTAL:
-                    _gm.width += resizeHorzStep(it->getParamI(0));
+                    if (it->getParamI(1) == UNIT_PERCENT) {
+                        Geometry head;
+                        X11::getHeadInfo(X11::getCurrHead(), head);
+                        _gm.width += (it->getParamI(0) * static_cast<int>(head.width)) / 100;
+                    } else {
+                        _gm.width +=  it->getParamI(0);
+                    }
                     if (! outline) {
                         resize(_gm.width, _gm.height);
                     }
                     break;
                 case RESIZE_VERTICAL:
-                    _gm.height += resizeVertStep(it->getParamI(0));
+                    if (it->getParamI(1) == UNIT_PERCENT) {
+                        Geometry head;
+                        X11::getHeadInfo(X11::getCurrHead(), head);
+                        _gm.height += (it->getParamI(0) * static_cast<int>(head.height)) / 100;
+                    } else {
+                        _gm.height +=  it->getParamI(0);
+                    }
                     if (! outline) {
                         resize(_gm.width, _gm.height);
                     }

--- a/src/PDecor.hh
+++ b/src/PDecor.hh
@@ -290,15 +290,6 @@ public:
     void doMove(int x_root, int y_root);
     void doKeyboardMoveResize(void);
 
-    // Only moveResize if any of the arguments is different than the
-    // current geometry.
-    void checkMoveResize(int x, int y, uint width, uint height) {
-        if (x != _gm.x || _gm.y != y
-            || _gm.width != width || _gm.height != height) {
-            moveResize(x, y, width, height);
-        }
-    }
-
     bool isFullscreen(void) const { return _fullscreen; }
 
     //! @brief Returns border position Window win is at.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,6 +47,11 @@ add_test(CfgParser test_CfgParser)
 target_include_directories(test_CfgParser PUBLIC ${common_INCLUDE_DIRS})
 target_link_libraries(test_CfgParser util ${common_LIBRARIES})
 
+add_executable(test_Config test_Config.cc)
+add_test(Config test_Config)
+target_include_directories(test_Config PUBLIC ${common_INCLUDE_DIRS})
+target_link_libraries(test_Config wm texture x11 util ${common_LIBRARIES})
+
 add_executable(test_Frame test_Frame.cc)
 add_test(Frame test_Frame)
 target_include_directories(test_Frame PUBLIC ${common_INCLUDE_DIRS})

--- a/test/system/test_update_client_list.cc
+++ b/test/system/test_update_client_list.cc
@@ -40,7 +40,7 @@ print_net_client_list(Display *dpy, Window root, Atom net_client_list)
     data = get_propery(dpy, root, net_client_list, nleft, &nread, &nleft);
     Window *wins = reinterpret_cast<Window*>(data);
     std::cout << "BEGIN WINDOWS" << std::endl;
-    for (int i = 0; i < nread; i++) {
+    for (unsigned long i = 0; i < nread; i++) {
         std::cout << "  Window " << wins[i] << std::endl;
     }
     std::cout << "END WINDOWS" << std::endl;

--- a/test/test_Config.cc
+++ b/test/test_Config.cc
@@ -1,0 +1,34 @@
+#include "test.hh"
+#include "Config.hh"
+#include "Action.hh"
+
+class TestConfig : public TestSuite,
+                   public Config {
+public:
+    TestConfig()
+        : TestSuite("Config"),
+          Config()
+    {
+        register_test("parseMoveResizeAction",
+                      std::bind(&TestConfig::testParseMoveResizeAction,
+                                this));
+    }
+
+    void testParseMoveResizeAction(void) {
+        Action action;
+        ASSERT_EQUAL("parse 1 ok", true, parseMoveResizeAction("Movehorizontal 1", action));
+        ASSERT_EQUAL("parsed value", 1, action.getParamI(0));
+        ASSERT_EQUAL("parsed unit", UNIT_PIXEL, action.getParamI(1));
+
+        ASSERT_EQUAL("parse -3% ok", true, parseMoveResizeAction("Movehorizontal -3%", action));
+        ASSERT_EQUAL("parsed value", -3, action.getParamI(0));
+        ASSERT_EQUAL("parsed unit", UNIT_PERCENT, action.getParamI(1));
+    }
+};
+
+int
+main(int argc, char *argv[])
+{
+    TestConfig testConfig;
+    TestSuite::main(argc, argv);
+}


### PR DESCRIPTION
This adds support for '%' to the move/resize commands, which I think is in line with SetGeometry accepting '%' elsewhere. The first three commits are actually (good I think) cleanup. The meat is in the last one. I don't have multiple monitor setup to test though (and I think those "heads" are about that).

My first time making real changes in pekwm, let me know if I did anything wrong, I can try to fix it.