### PR TITLE
Do not start pekwm_bg when ThemeBackground is set to false

### DIFF
--- a/src/WindowManager.cc
+++ b/src/WindowManager.cc
@@ -505,7 +505,7 @@ WindowManager::startBackground(const std::string& theme_dir,
                                const std::string& texture)
 {
     stopBackground();
-    if (! texture.empty()) {
+    if (pekwm::config()->getThemeBackground() && ! texture.empty()) {
         std::vector<std::string> args =
             {BINDIR "/pekwm_bg", "--load-dir", theme_dir + "/backgrounds",
              texture};


### PR DESCRIPTION
The config key is parsed and obtainable via getThemeBackground()
call. But it's never called. So whatever you set in config file, theme
background is always used.