### PR TITLE
Move the horz line down to bottom in faq.md

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -380,11 +380,11 @@ Screen {
     HonourRandr = "False"
 ```
 
-***
-
 ### Mouse scrolling does not work with GTK3 applications?
 
 You need to set the environment variable `GDK_CORE_DEVICE_EVENTS` to
 1.
+
+***
 
 [< Previous (Themes)](themes.md) - [(Development) Next >](development.md)


### PR DESCRIPTION
This line is to separate the header and footer from the rest. I didn't
notice this when I added a new faq entry, after it instead of before it.