### PR TITLE
Disable move/resize on fullscreen windows

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1172,7 +1172,7 @@ Frame::doResize(BorderPosition pos)
 void
 Frame::doResize(bool left, bool x, bool top, bool y)
 {
-    if (! _client->allowResize() || isShaded()) {
+    if (! _client->allowResize() || isShaded() || _client->isFullscreen()) {
         return;
     }
 

--- a/src/MoveEventHandler.hh
+++ b/src/MoveEventHandler.hh
@@ -95,7 +95,7 @@ public:
     virtual EventHandler::Result
     handleMotionNotifyEvent(XMotionEvent *ev) override
     {
-        if (! _decor) {
+        if (! _decor || _decor->isFullscreen()) {
             return stopMove();
         }
 

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -1158,6 +1158,9 @@ PDecor::moveChildRel(int off)
 void
 PDecor::doKeyboardMoveResize(void)
 {
+    if (_fullscreen) {
+        return;
+    }
     auto sw = pekwm::statusWindow();
     if (! X11::grabPointer(X11::getRoot(), NoEventMask, CURSOR_MOVE)) {
         return;


### PR DESCRIPTION
This is reported in #52. For fullscreen windows, I think it's
uncontroversal that actions to move or resize are unwanted. After all
you have occupied full screen, there's nowhere else to move to, and
resize it to something smaller could potentially break the app that
assumes in fullscreen mode.

This commit therefore disables move/resize actions from both keyboard
and mouse. You'll need to unfullscreen first before you can do those
again.