### PR TITLE
Support config files in XDG config location

### DIFF
--- a/doc/basic-usage.md
+++ b/doc/basic-usage.md
@@ -41,6 +41,11 @@ start, vars. You will learn more about these files in the
 All this happens behind-the-scenes, so by default, you'll be placed
 into a nice working environment.
 
+If you prefer XDG config layout, you could move `~/.pekwm` to
+`~/.config/pekwm` (or `$XDG_CONFIG_HOME/pekwm` to be exact). The rest
+of the document still refers to `~/.pekwm`, but it still works the
+same way.
+
 ### About Menus and Iconification
 
 When you iconify (This is the traditional name in unix. Windows calls

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -163,14 +163,10 @@ As previously indicated, the config file follows the rules defined in
 Here's an example ~/.pekwm/config file:
 
 ```
+INCLUDE = "$_PEKWM_ETC_PATH/config_system"
+
 Files {
-	Keys = "~/.pekwm/keys"
-	Mouse = "~/.pekwm/mouse"
-	Menu = "~/.pekwm/menu"
-	Start = "~/.pekwm/start"
-	AutoProps = "~/.pekwm/autoproperties"
-	Theme = "~/.pekwm/themes/default"
-	Icons = "~/.pekwm/icons/"
+	Theme = "$_PEKWM_THEME_PATH/default"
 }
 
 MoveResize {
@@ -256,6 +252,22 @@ Harbour {
 		SideMin = "64"
 		SideMax = "0"
 	}
+}
+```
+
+If you prefer XDG config files, please note that by default the
+`config_system` file specifies files in `~/.pekwm`. You need to update
+the `Files` section to point to the right places, e.g.
+
+```
+Files {
+    Theme = "$_PEKWM_THEME_PATH/default"
+    Keys = "~/.config/pekwm/keys"
+    Mouse = "~/.config/pekwm/mouse"
+    Menu = "~/.config/pekwm/menu"
+    Start = "~/.config/pekwm/start"
+    AutoProps = "~/.config/pekwm/autoproperties"
+    Icons = "~/.config/pekwm/icons/"
 }
 ```
 

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -165,7 +165,7 @@ Config::Config(void) :
         _menu_focus_opacity(EWMH_OPAQUE_WINDOW),
         _menu_unfocus_opacity(EWMH_OPAQUE_WINDOW),
         _cmd_dialog_history_unique(true), _cmd_dialog_history_size(1024),
-        _cmd_dialog_history_file("~/.pekwm/history"), _cmd_dialog_history_save_interval(16),
+        _cmd_dialog_history_file(Util::getConfig("history")), _cmd_dialog_history_save_interval(16),
         _harbour_da_min_s(0), _harbour_da_max_s(0),
         _harbour_ontop(true), _harbour_maximize_over(false),
         _harbour_placement(TOP), _harbour_orientation(TOP_TO_BOTTOM), _harbour_head_nr(0),
@@ -656,7 +656,7 @@ Config::loadCmdDialog(CfgParser::Entry *section)
                                                 1024, 1));
     keys.push_back(new CfgParserKeyPath("HISTORYFILE",
                                         _cmd_dialog_history_file,
-                                        "~/.pekwm/history"));
+                                        Util::getConfig("history")));
     keys.push_back(new CfgParserKeyNumeric<int>("HISTORYSAVEINTERVAL",
                                               _cmd_dialog_history_save_interval,
                                                 16, 0));
@@ -988,7 +988,7 @@ Config::tryHardLoadConfig(CfgParser &cfg, std::string &file)
 
     // Try loading ~/.pekwm/config
     if (! success) {
-        file = Util::getEnv("HOME") + "/.pekwm/config";
+        file = Util::getConfig("config");
         success = cfg.parse(file, CfgParserSource::SOURCE_FILE, true);
 
         // Copy cfg files to ~/.pekwm and try loading ~/.pekwm/config again.
@@ -1011,7 +1011,7 @@ Config::tryHardLoadConfig(CfgParser &cfg, std::string &file)
 void
 Config::copyConfigFiles(void)
 {
-    std::string cfg_dir = Util::getEnv("HOME") + "/.pekwm";
+    std::string cfg_dir = Util::getConfig("");
 
     std::string cfg_file = cfg_dir + std::string("/config");
     std::string keys_file = cfg_dir + std::string("/keys");

--- a/src/Util.hh
+++ b/src/Util.hh
@@ -112,6 +112,7 @@ namespace Util {
     std::string getHostname(void);
 
     bool isFile(const std::string &file);
+    bool isDir(const std::string &file);
     bool isExecutable(const std::string &file);
     time_t getMtime(const std::string &file);
 
@@ -126,6 +127,8 @@ namespace Util {
                      std::vector<std::string> &vals,
                      const char *sep, uint max = 0,
                      bool include_empty = false, char escape = '\0');
+
+    std::string getConfig(const std::string &entry);
 
     template<class T> std::string to_string(T t) {
         std::ostringstream oss;

--- a/src/pekwm_dialog.cc
+++ b/src/pekwm_dialog.cc
@@ -655,7 +655,7 @@ int main(int argc, char* argv[])
     }
 
     if (config_file.empty()) {
-        config_file = "~/.pekwm/config";
+        config_file = Util::getConfig("config");
     }
     Util::expandFileName(config_file);
 

--- a/src/pekwm_wm.cc
+++ b/src/pekwm_wm.cc
@@ -135,7 +135,7 @@ main(int argc, char **argv)
                           << "$HOME not set." << std::endl;
                 stop(write_fd, "error", nullptr);
             }
-            config_file = home + "/.pekwm/config";
+            config_file = Util::getConfig("config");
         }
     }
 


### PR DESCRIPTION
This adds a new function, Util::getConfig() that would pick up config
files from either ~/.pekwm or ~/.config/pekwm [1]. If both exist, or
none exists, ~/.pekwm is preferred.

This is I suppose just personal preferences. Some might prefer to
clutter $HOME less (and $XDG_CONFIG_HOME more).

[1] https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html