### PR TITLE
Support SetGeometry command in MoveResize block

### DIFF
--- a/src/Config.cc
+++ b/src/Config.cc
@@ -778,6 +778,8 @@ Config::parseMoveResizeAction(const std::string &action_string, Action &action)
             }
 
             return true;
+        } else {
+            USER_WARN("Unknown move/resize action: " << tok[0]);
         }
     }
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -824,7 +824,9 @@ Frame::setupAPGeometry(Client *client, AutoProperty *ap)
     // get frame geometry
     if (ap->isMask(AP_FRAME_GEOMETRY)) {
         Geometry screen_gm = X11::getScreenGeometry();
-        setGeometry(ap->frame_gm, ap->frame_gm_mask, screen_gm);
+        Geometry gm;
+        applyGeometry(gm, ap->frame_gm, ap->frame_gm_mask, screen_gm);
+        moveResize(gm, ap->frame_gm_mask);
     }
 }
 
@@ -1844,20 +1846,9 @@ Frame::setGeometry(const std::string geometry, int head, bool honour_strut)
         }
     }
 
-    setGeometry(gm, mask, screen_gm);
-}
-
-void
-Frame::setGeometry(const Geometry &geometry, int gm_mask,
-                   const Geometry &screen_gm)
-{
-    applyGeometry(_gm, geometry, gm_mask, screen_gm);
-    if (gm_mask&(X_VALUE|Y_VALUE)) {
-        move(_gm.x, _gm.y);
-    }
-    if (gm_mask&(WIDTH_VALUE|HEIGHT_VALUE)) {
-        resize(_gm.width, _gm.height);
-    }
+    Geometry applied_gm;
+    applyGeometry(applied_gm, gm, mask, screen_gm);
+    moveResize(applied_gm, mask);
 }
 
 void

--- a/src/Frame.hh
+++ b/src/Frame.hh
@@ -113,8 +113,6 @@ public:
 
     void setGeometry(const std::string geometry, int head=-1,
                      bool honour_strut=false);
-    void setGeometry(const Geometry &geometry, int gm_mask,
-                     const Geometry &head);
 
     void growDirection(uint direction);
     void moveToHead(int head_nr);

--- a/src/KeyboardMoveResizeEventHandler.hh
+++ b/src/KeyboardMoveResizeEventHandler.hh
@@ -129,6 +129,8 @@ public:
     EventHandler::Result
     runMoveResizeAction(const Action& action)
     {
+        int gm_mask = 0;
+
         switch (action.getAction()) {
         case MOVE_HORIZONTAL:
             if (action.getParamI(1) == UNIT_PERCENT) {
@@ -139,9 +141,7 @@ public:
             } else {
                 _gm.x += action.getParamI(0);
             }
-            if (! _outline) {
-                _decor->move(_gm.x, _gm.y);
-            }
+            gm_mask = X_VALUE;
             break;
         case MOVE_VERTICAL:
             if (action.getParamI(1) == UNIT_PERCENT) {
@@ -152,9 +152,7 @@ public:
             } else {
                 _gm.y +=  action.getParamI(0);
             }
-            if (! _outline) {
-                _decor->move(_gm.x, _gm.y);
-            }
+            gm_mask = Y_VALUE;
             break;
         case RESIZE_HORIZONTAL:
             if (action.getParamI(1) == UNIT_PERCENT) {
@@ -165,9 +163,7 @@ public:
             } else {
                 _gm.width +=  action.getParamI(0);
             }
-            if (! _outline) {
-                _decor->resize(_gm.width, _gm.height);
-            }
+            gm_mask = WIDTH_VALUE;
             break;
         case RESIZE_VERTICAL:
             if (action.getParamI(1) == UNIT_PERCENT) {
@@ -178,41 +174,34 @@ public:
             } else {
                 _gm.height +=  action.getParamI(0);
             }
-            if (! _outline) {
-                _decor->resize(_gm.width, _gm.height);
-            }
+            gm_mask = HEIGHT_VALUE;
             break;
         case MOVE_SNAP:
             PDecor::checkSnap(_decor, _gm);
-            if (! _outline) {
-                _decor->move(_gm.x, _gm.y);
-            }
+            gm_mask = X_VALUE | Y_VALUE;
             break;
         case MOVE_CANCEL:
+            gm_mask = _old_gm.diffMask(_gm);
             _gm = _old_gm; // restore position
 
             if (! _outline) {
-                _decor->move(_gm.x, _gm.y);
-                _decor->resize(_gm.width, _gm.height);
+                _decor->moveResize(_old_gm, gm_mask);
             }
 
             return EventHandler::EVENT_STOP_PROCESSED;
         case MOVE_END:
             if (_outline) {
-                if (_gm.x != _old_gm.x
-                    || _gm.y != _old_gm.y) {
-                    _decor->move(_gm.x, _gm.y);
-                }
-                if (_gm.width != _old_gm.width
-                    || _gm.height != _old_gm.height) {
-                    _decor->resize(_gm.width, _gm.height);
-                }
+                gm_mask = _gm.diffMask(_old_gm);
+                _decor->moveResize(_gm, gm_mask);
             }
             return EventHandler::EVENT_STOP_PROCESSED;
         default:
             break;
         }
 
+        if (! _outline) {
+            _decor->moveResize(_gm, gm_mask);
+        }
         return EventHandler::EVENT_PROCESSED;
     }
 

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -420,6 +420,30 @@ PDecor::resize(uint width, uint height)
     renderBorder();
 }
 
+void
+PDecor::moveResize(const Geometry &gm, int gm_mask)
+{
+    if (gm_mask & (X_VALUE|Y_VALUE)) {
+        if (gm_mask & X_VALUE) {
+            _gm.x = gm.x;
+        }
+        if (gm_mask & Y_VALUE) {
+            _gm.y = gm.y;
+        }
+        move(_gm.x, _gm.y);
+    }
+
+    if (gm_mask & (WIDTH_VALUE|HEIGHT_VALUE)) {
+        if (gm_mask & WIDTH_VALUE) {
+            _gm.width = gm.width;
+        }
+        if (gm_mask & HEIGHT_VALUE) {
+            _gm.height = gm.height;
+        }
+        resize(_gm.width, _gm.height);
+    }
+}
+
 //! @brief Move and resize window.
 void
 PDecor::moveResize(int x, int y, uint width, uint height)

--- a/src/PDecor.hh
+++ b/src/PDecor.hh
@@ -133,6 +133,8 @@ public:
     virtual void raise(void) override;
     virtual void lower(void) override;
 
+    void moveResize(const Geometry &geometry, int gm_mask);
+
     virtual void setFocused(bool focused) override;
     virtual void setWorkspace(uint workspace) override;
 

--- a/src/x11.hh
+++ b/src/x11.hh
@@ -212,6 +212,22 @@ public:
         return (x != gm.x) || (y != gm.y) ||
                 (width != gm.width) || (height != gm.height);
     }
+    inline int diffMask(const Geometry &old_gm) {
+        int mask = 0;
+        if (x != old_gm.x) {
+            mask |= X_VALUE;
+        }
+        if (y != old_gm.y) {
+            mask |= Y_VALUE;
+        }
+        if (width != old_gm.width) {
+            mask |= WIDTH_VALUE;
+        }
+        if (height != old_gm.height) {
+            mask |= HEIGHT_VALUE;
+        }
+        return mask;
+    }
 };
 
 /**


### PR DESCRIPTION
OK here's the first attempt. Only tested lightly (and seems to work) but I want to check if this is the right direction to go first. Sum up:

* Frame::setGeomtry() is broken into two pieces, the parsing/calculation and the action
* MoveResize handler now takes a Frame instead of PDecor. I'm pretty sure they are always the same when the handler is created
* MoveResize config includes parsing for SetGeometry
* MoveResize handler calls the first piece, then depending on outline mode, do the action separately

I think this is my first multiple commit PR too. Let me know if you prefer this way or just one big commit, or multiple small-and-nice PRs.

Document to be updated later.