### PR TITLE
Make ACTION_MENU_SELECT act as ENTER_SUBMENU when applicable

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -593,7 +593,7 @@ Goes to item number int. First item in menu is 1.
 
 **Select**
 
-Selects the current menu item.
+Selects the current menu item. If it's a submenu, enter the submenu.
 
 >Menu-specific keybinding
 

--- a/src/ActionHandler.cc
+++ b/src/ActionHandler.cc
@@ -236,17 +236,18 @@ ActionHandler::handleAction(const ActionPerformed &ap)
                 menu->selectItemNum(it->getParamI(0));
                 break;
             case ACTION_MENU_SELECT:
-                menu->exec(menu->getItemCurr());
-
-                // special case: execItem can cause an reload to be issued, if that's
-                // the case it causes the list (ae) to change and therefore
-                // it can't be used anymore
-                return;
             case ACTION_MENU_ENTER_SUBMENU:
                 if (menu->getItemCurr() &&
                         menu->getItemCurr()->getWORef() &&
                         (menu->getItemCurr()->getWORef()->getType() == PWinObj::WO_MENU)) {
                     menu->mapSubmenu(static_cast<PMenu*>(menu->getItemCurr()->getWORef()), true);
+                } else if (it->getAction() == ACTION_MENU_SELECT) {
+                    menu->exec(menu->getItemCurr());
+
+                    // special case: execItem can cause an reload to be issued, if that's
+                    // the case it causes the list (ae) to change and therefore
+                    // it can't be used anymore
+                    return;
                 }
                 break;
             case ACTION_MENU_LEAVE_SUBMENU:


### PR DESCRIPTION
At some point I was surprised that when I press enter on a submenu, the
menu closes. The natural behavior (only verified after with firefox) is
Enter expands the submenu. This changes ACTION_MENU_SELECT to do just
that.

(small and nice improvement, i think)