### PR TITLE
Allow SYSCONFDIR override

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ else (HAS_CXX11)
   message(FATAL_ERROR "Compiler with C++11 support is required")
 endif (HAS_CXX11)
 
+# Add support for more install configuration
+include(GNUInstallDirs)
+
 # Look for dependencies
 find_package(X11 REQUIRED)
 find_package(Iconv REQUIRED)
@@ -115,7 +118,7 @@ add_definitions(-DVERSION="${pekwm_VERSION}"
   -DFEATURES="${pekwm_FEATURES}"
   -DBINDIR="${CMAKE_INSTALL_PREFIX}/bin"
   -DDATADIR="${CMAKE_INSTALL_PREFIX}/share"
-  -DSYSCONFDIR="${CMAKE_INSTALL_PREFIX}/etc/pekwm")
+  -DSYSCONFDIR="${CMAKE_INSTALL_FULL_SYSCONFDIR}/pekwm")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH True)
 
 # Subdirectories

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -17,4 +17,4 @@ install(FILES
   panel
   start
   vars
-  DESTINATION etc/pekwm/)
+  DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/pekwm/)

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -152,7 +152,7 @@ with the --version parameter to find the right executable to
 keep. Note to give the full path to the executable when querying for
 the version (**/usr/local/bin/pekwm --version**).
 
-### Can I turn off this sloppy focus crap?
+### Can I turn off sloppy focus option?
 
 Yes. You can. You need to make all enter and leave events not affect
 the focus of frames, borders, clients. See the comments above the
@@ -410,6 +410,13 @@ argument to true to include iconified windows as well, e.g.
 ```
 	KeyPress = "Mod1 Tab" { Actions = "NextFrameMRU TempRaise True" }
 ```
+
+### What if I must change system-wide configuration files location?
+
+By default pekwm installs its configuration files in /usr/etc/pekwm. However this
+can be overridden if your distro defaults its system-wide configuration files in
+a different location using the option -DCMAKE_INSTALL_SYSCONFDIR=/foo. See
+[overview.md](overview.md#compiling-pekwm) for configure options, building and installing.
 
 ***
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -192,10 +192,12 @@ the cmake command line as:
 
 | Option               | Default    | Description                                                   |
 |----------------------|------------|---------------------------------------------------------------|
-| CMAKE_INSTALL_PREFIX | /usr/local | It may be useful to use a custom prefix to install the files. |
-| CMAKE_BUILD_TYPE     |            | Set to Debug to enable debug outputs and code                 |
-| PEDANTIC             | OFF        | Turn on extra compiler warnings                               |
-| TESTS                | OFF        | Enable compilation of unit test programs                      |
+| CMAKE_INSTALL_PREFIX      | /usr/local       | It may be useful to use a custom prefix to install the files. |
+| CMAKE_INSTALL_SYSCONFDIR | /usr/etc/pekwm | It may be useful to use a custom prefix to install the config files. |
+| CMAKE_BUILD_TYPE         |                | Set to Debug to enable debug outputs and code                 |
+| DEBUG                    | OFF              | Enable debug outputs and code                                 |
+| PEDANTIC                 | OFF              | Turn on extra compiler warnings                               |
+| TESTS                    | OFF              | Enable compilation of unit test programs                      |
 
 ### Options to reduce the size
 
@@ -211,8 +213,8 @@ the cmake command line as:
 
 ### Building and installing
 
-After running cmake with any options you need, run **make**. This
-should only take a few minutes. After that, become root (unless you
+After running cmake with any configuration options you need, run **make**.
+This should only take a few minutes. After that, become root (unless you
 used a prefix in your home directory, such as
 -DCMAKE_INSTALL_PREFIX=/home/you/pkg) and type **make install**
 


### PR DESCRIPTION
Locally tested in voidlinux build container
Usage: override with setting -DSYSCONFDIR=/foo

@pclouds please test how this behaves on ebuild for you

closes https://github.com/pekdon/pekwm/issues/69