### PR TITLE
Add new parameter "raise" in SendToWorkspace (#75)

### DIFF
--- a/data/keys
+++ b/data/keys
@@ -35,10 +35,10 @@ Global {
         KeyPress = "Mod4 7" { Actions = "GotoWorkspace 7" }
         KeyPress = "Mod4 8" { Actions = "GotoWorkspace 8" }
         KeyPress = "Mod4 9" { Actions = "GotoWorkspace 9" }
-        KeyPress = "Ctrl Mod1 Shift Left" { Actions = "SendToWorkspace Next; GoToWorkspace Next" }
-        KeyPress = "Ctrl Mod1 Shift Right" { Actions = "SendToWorkspace Prev; GoToWorkspace Prev" }
-        KeyPress = "Ctrl Mod1 Shift Up" { Actions = "SendToWorkspace NextV; GoToWorkspace NextV" }
-        KeyPress = "Ctrl Mod1 Shift Down" { Actions = "SendToWorkspace PrevV; GoToWorkspace PrevV" }
+        KeyPress = "Ctrl Mod1 Shift Left" { Actions = "SendToWorkspace Next KeepFocus; GoToWorkspace Next" }
+        KeyPress = "Ctrl Mod1 Shift Right" { Actions = "SendToWorkspace Prev KeepFocus; GoToWorkspace Prev" }
+        KeyPress = "Ctrl Mod1 Shift Up" { Actions = "SendToWorkspace NextV KeepFocus; GoToWorkspace NextV" }
+        KeyPress = "Ctrl Mod1 Shift Down" { Actions = "SendToWorkspace PrevV KeepFocus; GoToWorkspace PrevV" }
         KeyPress = "Mod4 Shift 1" { Actions = "SendToWorkspace 1" }
         KeyPress = "Mod4 Shift 2" { Actions = "SendToWorkspace 2" }
         KeyPress = "Mod4 Shift 3" { Actions = "SendToWorkspace 3" }
@@ -221,8 +221,8 @@ Global {
                 KeyPress = "7" { Actions = "GoToWorkspace 7" }
                 KeyPress = "8" { Actions = "GoToWorkspace 8" }
                 KeyPress = "9" { Actions = "GoToWorkspace 9" }
-                KeyPress = "Up" { Actions = "SendToWorkspace Next; GoToWorkspace Next" }
-                KeyPress = "Down" { Actions = "SendToWorkspace Prev; GoToWorkspace Prev" }
+                KeyPress = "Up" { Actions = "SendToWorkspace Next KeepFocus; GoToWorkspace Next" }
+                KeyPress = "Down" { Actions = "SendToWorkspace Prev KeepFocus; GoToWorkspace Prev" }
                 KeyPress = "F1" { Actions = "SendToWorkspace 1" }
                 KeyPress = "F2" { Actions = "SendToWorkspace 2" }
                 KeyPress = "F3" { Actions = "SendToWorkspace 3" }

--- a/doc/actions.md
+++ b/doc/actions.md
@@ -402,7 +402,7 @@ parameter.
 
 Detach the current client from its frame.
 
-**SendToWorkspace (string)**
+**SendToWorkspace (string) [keepfocus]**
 
 Sends a frame to the specified workspace. String is one of:
 
@@ -416,6 +416,9 @@ Sends a frame to the specified workspace. String is one of:
 * _down_
 * _last_, send to workspace you last used before the current
 * _int_, integer is a workspace number to send to to
+
+If the second argument is "keepfocus", the window remains focused in
+the new workspace. Default no keepfocus.
 
 **GotoWorkspace (string)**
 

--- a/src/ActionHandler.hh
+++ b/src/ActionHandler.hh
@@ -47,7 +47,7 @@ private:
     void actionFindClient(const std::wstring &title);
     void actionGotoClientID(uint id);
     void actionGotoWorkspace(uint workspace, bool warp);
-    void actionSendToWorkspace(PDecor *decor, int direction);
+    void actionSendToWorkspace(PDecor *decor, bool focus, int direction);
     void actionWarpToWorkspace(PDecor *decor, uint direction);
     void actionFocusDirectional(PWinObj *wo, DirectionType dir, bool raise);
     bool actionSendKey(PWinObj *wo, const std::string &key_str);
@@ -68,7 +68,7 @@ private:
     void attachMarked(Frame *frame);
     void attachInNextPrevFrame(Client *client, bool frame, bool next);
 
-    int calcWorkspaceNum(const Action& action);
+    int calcWorkspaceNum(const Action& action, int index = 0);
 
     void setEventHandler(EventHandler *event_handler);
 


### PR DESCRIPTION
The new parameter is meant to be used in the "SendToWorkspace;
GotoWorkspace" command sequence. It makes more sense [1] that the window
you are moving remains focused and on top in the new workspace, so that
you can continue to do whatever you want with it.

This also makes it possible to move the window across multiple
workspaces fast (otherwise you would need find and focus the window
before moving again).

The name "raise" was chosen because I was thinking of

    SendToWorkspace <direction>; Raise; GotoWorkspace

and actually tried that out before realizing it's "raising" one of the
windows in the current workspace, not the old one.

[1] which is also why I've updated data/keys to always use "raise" in
combination with GotoWorkspace.