### PR TITLE
Do let clients steal focus from fullscreen sometimes

### DIFF
--- a/src/Client.hh
+++ b/src/Client.hh
@@ -175,7 +175,7 @@ public: // Public Member Functions
     bool isMaximizedVert(void) const { return _state.maximized_vert; }
     bool isMaximizedHorz(void) const { return _state.maximized_horz; }
     bool isShaded(void) const { return _state.shaded; }
-    bool isFullscreen(void) const { return _state.fullscreen; }
+    bool isFullscreen(void) const override { return _state.fullscreen; }
     bool isPlaced(void) const { return _state.placed; }
     uint getInitialFrameOrder(void) const { return _state.initial_frame_order; }
     uint getSkip(void) const { return _state.skip; }

--- a/src/PWinObj.hh
+++ b/src/PWinObj.hh
@@ -145,7 +145,7 @@ public:
     inline bool isFocusable(void) const { return _focusable; }
     //! @brief Returns true if the PWinObj is interested in keyboard input
     inline bool isKeyboardInput(void) const { return _keyboard_input; }
-    inline bool isFullscreen(void) const { return _fullscreen; }
+    virtual bool isFullscreen(void) const { return _fullscreen; }
 
     //! @brief Returns transparency state of PWinObj
     inline bool isOpaque(void) const { return _opaque; }

--- a/src/WindowManager.cc
+++ b/src/WindowManager.cc
@@ -1475,7 +1475,8 @@ WindowManager::createClient(Window window, bool is_new)
 
                 if (wo != nullptr
                     && wo->isMapped()
-                    && (wo->getParent()->isFullscreen()
+                    && ((pekwm::config()->isFullscreenAbove()
+                         && wo->isFullscreen())
                         || (wo->isKeyboardInput()
                             && time_protect
                             && time_protect >= (X11::getLastEventTime()


### PR DESCRIPTION
The commit 974254f (Don't let new client steal focus from fullscreen
window, 2021-04-04) forbids new client from stealing focus from a
fullscreen window because the visible window in that case is still the
fullscreen window.

But that is only true when FullscreenAbove configuration is set to True,
which puts fullscreen windows on their own layer above the normal
one. If this is set to false, a fullscreen window should still be in
normal layer, and the new client should be able to show up. Which means
no need to prevent them from getting focus (and we must not because it
causes the same confusion again the other way around)