### PR TITLE
Add $_PEKWM_CONFIG_PATH and avoid hard coding ~/.pekwm

### DIFF
--- a/data/config_system
+++ b/data/config_system
@@ -1,11 +1,11 @@
 Files {
-    Keys = "~/.pekwm/keys"
-    Mouse = "~/.pekwm/mouse"
-    Menu = "~/.pekwm/menu"
-    Start = "~/.pekwm/start"
-    AutoProps = "~/.pekwm/autoproperties"
+    Keys = "$_PEKWM_CONFIG_PATH/keys"
+    Mouse = "$_PEKWM_CONFIG_PATH/mouse"
+    Menu = "$_PEKWM_CONFIG_PATH/menu"
+    Start = "$_PEKWM_CONFIG_PATH/start"
+    AutoProps = "$_PEKWM_CONFIG_PATH/autoproperties"
     Theme = "$_PEKWM_THEME_PATH/default"
-    Icons = "~/.pekwm/icons/"
+    Icons = "$_PEKWM_CONFIG_PATH/icons/"
 }
 
 MoveResize {
@@ -95,7 +95,7 @@ Menu {
 CmdDialog {
     HistoryUnique = "True"
     HistorySize = "1024"
-    HistoryFile = "~/.pekwm/history"
+    HistoryFile = "$_PEKWM_CONFIG_PATH/history"
     HistorySaveInterval = "16"
 }
 

--- a/data/menu
+++ b/data/menu
@@ -34,7 +34,7 @@ RootMenu = "Pekwm" {
   Submenu = "pekwm" {
     Submenu = "Themes" {
       Entry { Actions = "Dynamic $_PEKWM_SCRIPT_PATH/pekwm_themeset.sh $_PEKWM_THEME_PATH" }
-      Entry { Actions = "Dynamic $_PEKWM_SCRIPT_PATH/pekwm_themeset.sh $_HOME/themes" }
+      Entry { Actions = "Dynamic $_PEKWM_SCRIPT_PATH/pekwm_themeset.sh $_PEKWM_CONFIG_PATH/themes" }
     }
     Entry = "Reload" { Actions = "Reload" }
     Entry = "Restart" { Actions = "Restart" }

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -146,6 +146,17 @@ starts, and it's contents will be used as the default config file. It
 will also be updated to point to the currently active config file if
 needed.
 
+A few other variables defined by pekwm:
+
+- $\_PEKWM\_ETC\_PATH points to the system configuration directory,
+  set at compile time. This is usually /etc.
+- $\_PEKWM\_SCRIPT\_PATH points to the "scripts" directory of pekwm,
+  e.g. /usr/share/pekwm/scripts.
+- $\_PEKWM\_THEME\_PATH points to the "themes" directory of pekwm,
+  e.g. /usr/share/pekwm/themes.
+- $\_PEKWM\_CONFIG\_PATH contains the directory path of
+  $\_PEKWM\_CONFIG\_FILE
+
 Variables can probably be defined almost anywhere, but it's probably a
 better idea to place them at the top of the file, outside of any
 sections.

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -271,6 +271,11 @@ Config::load(const std::string &config_file)
     auto cfg_env = Util::getEnv("PEKWM_CONFIG_FILE");
     if (cfg_env.size() == 0 || _config_file.compare(cfg_env) != 0) {
         setenv("PEKWM_CONFIG_FILE", _config_file.c_str(), 1);
+
+        auto sep = _config_file.rfind('/');
+        if (sep != std::string::npos) {
+            setenv("PEKWM_CONFIG_PATH", _config_file.substr(0, sep).c_str(), 1);
+        }
     }
 
     std::string o_file_mouse; // temporary filepath for mouseconfig

--- a/src/pekwm_wm.cc
+++ b/src/pekwm_wm.cc
@@ -132,6 +132,10 @@ main(int argc, char **argv)
             config_file = home + "/.pekwm/config";
         }
     }
+    auto sep = config_file.rfind('/');
+    if (sep != std::string::npos) {
+        setenv("PEKWM_CONFIG_PATH", config_file.substr(0, sep).c_str(), 1);
+    }
 
     USER_INFO("Starting pekwm. Use this information in bug reports: "
               << FEATURES << std::endl


### PR DESCRIPTION
This makes the system configuration files friendlier to people who do
not keep user config files at ~/.pekwm. All $_PEKWM_* variables are now
also documented.