### PR TITLE
Correct maximized state after SetGeometry command

### DIFF
--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1325,17 +1325,22 @@ Frame::doResize(bool left, bool x, bool top, bool y)
 	X11::ungrabPointer();
 
 	// Make sure the state isn't set to maximized after we've resized.
+	clearMaximizedStatesAfterResize();
+
+	if (outline) {
+		moveResize(_gm.x, _gm.y, _gm.width, _gm.height);
+		X11::ungrabServer(true);
+	}
+}
+
+void Frame::clearMaximizedStatesAfterResize()
+{
 	if (_maximized_horz || _maximized_vert) {
 		_maximized_horz = false;
 		_maximized_vert = false;
 		_client->setMaximizedHorz(false);
 		_client->setMaximizedVert(false);
 		_client->updateEwmhStates();
-	}
-
-	if (outline) {
-		moveResize(_gm.x, _gm.y, _gm.width, _gm.height);
-		X11::ungrabServer(true);
 	}
 }
 

--- a/src/Frame.hh
+++ b/src/Frame.hh
@@ -168,6 +168,7 @@ protected:
 	virtual int resizeVertStep(int diff) const;
 
 	virtual std::string getDecorName(void);
+	virtual void clearMaximizedStatesAfterResize();
 	// END - PDecor interface
 
 	static void applyGeometry(Geometry &gm, const Geometry &ap_gm, int mask);

--- a/src/PDecor.cc
+++ b/src/PDecor.cc
@@ -471,6 +471,7 @@ PDecor::moveResize(const Geometry &gm, int gm_mask)
 		if (gm_mask & HEIGHT_VALUE) {
 			_gm.height = gm.height;
 		}
+		clearMaximizedStatesAfterResize();
 		resize(_gm.width, _gm.height);
 	}
 }

--- a/src/PDecor.hh
+++ b/src/PDecor.hh
@@ -295,6 +295,8 @@ protected:
 
 	virtual int resizeHorzStep(int diff) const { return diff; }
 	virtual int resizeVertStep(int diff) const { return diff; }
+
+	virtual void clearMaximizedStatesAfterResize() { }
 	// END - PDecor interface.
 
 #ifdef PEKWM_HAVE_SHAPE


### PR DESCRIPTION
Toggle to maximize a window, execute SetGeometry to move it in a corner,
toggle maximizing again. One would expect the window to go back
maximized because SetGeometry un-maximizes the window, but it's
not. This is the fix.

There are two versions of moveResize(). The one that takes x, y, width
and height leave maximized state handling to the callers (all in
Frame.cc it seems). The other one being updated here is used by
SetGeomtry and MoveResize commands, which I think should update
maximized state correctly.

The second version is also used by setupAPGeometry() and this is where
I'm not sure if clearing maximized state automatically is appropriate...