### PR TITLE
Fix off-by-one workspace numbers in placement autoprops

### DIFF
--- a/src/AutoProperties.cc
+++ b/src/AutoProperties.cc
@@ -899,7 +899,7 @@ AutoProperties::parseAutoPropertyValue(CfgParser::Entry *section,
 			break;
 		case AP_WORKSPACE:
 			try {
-				prop->workspace = std::stoi((*it)->getValue());
+				prop->workspace = std::stoi((*it)->getValue()) - 1;
 				prop->maskAdd(AP_WORKSPACE);
 			} catch (std::invalid_argument&) {
 			}


### PR DESCRIPTION
Before 44653a8 (Drop C++11 requirement from the codebase, C++98 is good
enough, 2021-04-22) workspace parse code is

    unsigned(strtol((*it)->getValue().c_str(), 0, 10) - 1);

and after it:

    std::stoi((*it)->getValue());

The " - 1" part got lost during the conversion. This should fix #105.