### PR TITLE
Update overview.md to include Void linux instructions.

### DIFF
--- a/doc/overview.md
+++ b/doc/overview.md
@@ -142,6 +142,20 @@ Build dependencies:
 # apt install libfontconfig1-dev libjpeg-dev libxext-dev libpng-dev libxft-dev libxpm-dev libxrandr-dev libxinerama-dev
 ```
 
+#### Void
+
+Development tools using the GCC C++ compiler:
+
+```
+# xbps-install cmake make gcc
+```
+
+Build dependencies:
+
+```
+# xbps-install fontconfig-devel libjpeg-turbo-devel libXext-devel libpng-devel libXft-devel libXpm-devel libXrandr-devel libXinerama-devel
+```
+
 #### OpenBSD
 
 OpenBSD comes with X11 and a compatible C++ compiler. To add the


### PR DESCRIPTION
Added in Void dependencies. Note the lack of G++ in the development tools, this is because atleast in the void repos, it is simply part of the gcc package, not on its own. As far as my own limited testing goes, this works perfectly fine. Yes the captials are needed, xbps is case sensitive.