### PR TITLE
Resize fullscreen/maximized windows on randr changes

### DIFF
--- a/src/ManagerWindows.cc
+++ b/src/ManagerWindows.cc
@@ -331,16 +331,24 @@ RootWO::handleLeaveEvent(XCrossingEvent *ev)
  * Makes sure the Geometry is inside the screen.
  */
 void
-RootWO::placeInsideScreen(Geometry& gm, bool without_edge)
+RootWO::placeInsideScreen(Geometry& gm, bool without_edge, bool fullscreen, bool maximized_virt, bool maximized_horz)
 {
 	uint head_nr = X11::getNearestHead(gm.x, gm.y);
 	Geometry head;
+	if (fullscreen) {
+		X11::getHeadInfo(head_nr, gm);
+		return;
+	}
 	if (without_edge) {
 		X11::getHeadInfo(head_nr, head);
 	} else {
 		getHeadInfoWithEdge(head_nr, head);
 	}
 
+	if (maximized_horz) {
+		gm.x = head.x;
+		gm.width = head.width;
+	}
 	if (gm.x + gm.width > head.x + head.width) {
 		gm.x = head.x + head.width - gm.width;
 	}
@@ -348,6 +356,10 @@ RootWO::placeInsideScreen(Geometry& gm, bool without_edge)
 		gm.x = head.x;
 	}
 
+	if (maximized_virt) {
+		gm.y = head.y;
+		gm.height = head.height;
+	}
 	if (gm.y + gm.height > head.y + head.height) {
 		gm.y = head.y + head.height - gm.height;
 	}

--- a/src/ManagerWindows.cc
+++ b/src/ManagerWindows.cc
@@ -333,7 +333,7 @@ RootWO::handleLeaveEvent(XCrossingEvent *ev)
 void
 RootWO::placeInsideScreen(Geometry& gm, bool without_edge, bool fullscreen, bool maximized_virt, bool maximized_horz)
 {
-	uint head_nr = X11::getNearestHead(gm.x, gm.y);
+	uint head_nr = X11::getNearestHead(gm.x + gm.width / 2, gm.y + gm.height / 2);
 	Geometry head;
 	if (fullscreen) {
 		X11::getHeadInfo(head_nr, gm);

--- a/src/ManagerWindows.hh
+++ b/src/ManagerWindows.hh
@@ -63,7 +63,7 @@ public:
 	virtual ActionEvent *handleEnterEvent(XCrossingEvent *ev);
 	virtual ActionEvent *handleLeaveEvent(XCrossingEvent *ev);
 
-	void placeInsideScreen(Geometry &gm, bool without_edge=false);
+	void placeInsideScreen(Geometry &gm, bool without_edge=false, bool fullscreen=false, bool maximized_vert=false, bool maximized_horz=false);
 	void getHeadInfoWithEdge(uint num, Geometry& head);
 
 	void updateGeometry(uint width, uint height);

--- a/src/Workspaces.cc
+++ b/src/Workspaces.cc
@@ -800,7 +800,9 @@ Workspaces::updateClientStackingList(void)
 }
 
 /**
- * Make sure window is inside screen boundaries.
+ * Make sure window is inside screen boundaries. If window is in
+ * fullscreen mode or maximized, resize to make sure it covers the new
+ * screen.
  */
 void
 Workspaces::placeWoInsideScreen(PWinObj *wo)
@@ -809,16 +811,20 @@ Workspaces::placeWoInsideScreen(PWinObj *wo)
 	Geometry gm_after(gm_before);
 
 	Strut *strut = 0;
+	bool maximized_virt = false;
+	bool maximized_horz = false;
 	if (wo->getType() == PWinObj::WO_FRAME) {
 		Client *client = static_cast<Frame*>(wo)->getActiveClient();
 		if (client) {
 			strut = client->getStrut();
+			maximized_virt = client->isMaximizedVert();
+			maximized_horz = client->isMaximizedHorz();
 		}
 	}
 
-	pekwm::rootWo()->placeInsideScreen(gm_after, strut);
+	pekwm::rootWo()->placeInsideScreen(gm_after, strut, wo->isFullscreen(), maximized_virt, maximized_horz);
 	if (gm_before != gm_after) {
-		wo->move(gm_after.x, gm_after.y);
+		wo->moveResize(gm_after.x, gm_after.y, gm_after.width, gm_after.height);
 	}
 }
 


### PR DESCRIPTION
When a randr change is detected, currently we try to make sure a window
is still (partly) visible by moving it to where it can be seen. But it
just makes more sense to do a bit more for windows that we calculate
width or height automatically: maximized or fullscreen windows.

For maximized ones, while it's possible for the user to do it manually,
it's quite cumbersome (you have to unmaximize first, then resize by
keyboard; no mouse because you probably don't see the edge). For
fullscreen that's probably impossible.

So, when randr change happens, we now try to resize these windows as
well.

There are two cases this could happen. The first is resolution change
with just one monitor. I've tested this.

The second is when you have two monitor setup with different sizes and
disable the primary (and large) monitor. Suddenly all the windows become
too large for the second and smaller one. This is where I notice this.
But unfortunately I don't have access to this setup at the moment, so I
can't verify it. But it should work the same in theory.