### PR TITLE
Support specifying harbour's head by (xrandr) name

### DIFF
--- a/doc/actions.md
+++ b/doc/actions.md
@@ -294,9 +294,10 @@ Moves the frame to the same relative position on another head. The
 window is shrunk to fit if it is larger than the new head, or resized
 if it's fullscreen or maximized.
 
-If head is not a number, it must be one of the following keywords to
-select the head relative to the current head: _left_, _right_, _up_
-and _down_.
+If head is not a number, it must be the name of the head (only if
+Randr is supported, and special name "primary" is also accepted) or
+the following keywords to select the head relative to the current
+head: _left_, _right_, _up_ and _down_.
 
 **MoveToEdge (string)**
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -400,7 +400,8 @@ Placement Models:
 | Orientation  | string  | From what to which direction the harbour expands. One of TopToBottom, BottomToTop, RightToLeft, LeftToRight.                      |
 | OnTop        | boolean | Whether or not the harbour is "always on top"                                                                                     |
 | MaximizeOver | boolean | Controls whether maximized clients will cover the harbour (true), or if they will stop at the edge of the harbour (false).        |
-| Head         | int     | When RandR or Xinerama is on, decides on what head the harbour resides on. Integer is the head number.                            |
+| Head         | int     | When RandR or Xinerama is on, decides on what head the harbour resides on. Integer is the head number. Default 0.                 |
+| HeadName     | string  | When RandR is on, decides on what head the harbour resides on by name (which could be found from `xrandr` command). A special name "primary" connects to the primary head. This option overwrites Head. |
 | Opacity      | int     | Sets the opacity/transparency for the harbour. A value of 100 means completely opaque, while 0 stands for completely transparent. |
 
 **Config File Elements under the DockApp-subsection of the Harbour-section:**

--- a/src/Config.cc
+++ b/src/Config.cc
@@ -674,6 +674,8 @@ Config::loadHarbour(CfgParser::Entry *section)
 					    _harbour_maximize_over, false));
 	keys.push_back(new CfgParserKeyNumeric<int>("HEAD",
 						    _harbour_head_nr, 0, 0));
+	keys.push_back(new CfgParserKeyString("HEADNAME",
+					      _harbour_head, "", 0));
 	keys.push_back(new CfgParserKeyString("PLACEMENT",
 					      value_placement, "RIGHT", 0));
 	keys.push_back(new CfgParserKeyString("ORIENTATION",
@@ -1383,4 +1385,18 @@ Config::parseOpacity(const std::string value, uint &focused, uint &unfocused)
 	CONV_OPACITY(focused);
 	CONV_OPACITY(unfocused);
 	return true;
+}
+
+int
+Config::getHarbourHead(void) const
+{
+	if (_harbour_head.empty()) {
+		return _harbour_head_nr;
+	}
+	int head = X11::findHeadByName(_harbour_head);
+	if (head == -1) {
+		// fallback to primary head, which should always be valid
+		head = X11::findHeadByName("PRIMARY");
+	}
+	return head;
 }

--- a/src/Config.hh
+++ b/src/Config.hh
@@ -201,7 +201,7 @@ public:
 
 	int getHarbourDAMinSide(void) const { return _harbour_da_min_s; }
 	int getHarbourDAMaxSide(void) const { return _harbour_da_max_s; }
-	int getHarbourHead(void) const { return _harbour_head_nr; }
+	int getHarbourHead(void) const;
 	bool isHarbourOntop(void) const { return _harbour_ontop; }
 	bool isHarbourMaximizeOver(void) const { return _harbour_maximize_over; }
 	uint getHarbourPlacement(void) const { return _harbour_placement; }
@@ -346,6 +346,7 @@ private:
 	bool _harbour_maximize_over;
 	uint _harbour_placement;
 	uint _harbour_orientation;
+	std::string _harbour_head;
 	int _harbour_head_nr;
 	uint _harbour_opacity;
 

--- a/src/Frame.cc
+++ b/src/Frame.cc
@@ -1418,8 +1418,10 @@ Frame::moveToHead(const std::string& arg)
 	} else if (StringUtil::ascii_ncase_equal(arg, "DOWN")) {
 		head_nr = X11Util::getNearestHead(*this, DIRECTION_NO, DIRECTION_DOWN);
 	} else {
-		head_nr = -1;
-		P_ERR("unrecognized MoveToHead argument: " << arg);
+		head_nr = X11::findHeadByName(arg);
+		if (head_nr == -1) {
+			P_ERR("unrecognized MoveToHead argument: " << arg);
+		}
 	}
 	if (head_nr != -1) {
 		moveToHead(head_nr);

--- a/src/X11.hh
+++ b/src/X11.hh
@@ -242,15 +242,20 @@ public: // member variables
 //! Output head, used to share same code with Xinerama and RandR
 class Head {
 public:
-	Head(int nx, int ny, uint nwidth, uint nheight)
-		: x(nx),
-		  y(ny),
-		  width(nwidth),
-		  height(nheight)
+	Head(int nx, int ny, uint nwidth, uint nheight,
+	     const char* nname = nullptr, bool nprimary = false) :
+		name(nname ? nname : ""),
+		primary(nprimary),
+		x(nx),
+		y(ny),
+		width(nwidth),
+		height(nheight)
 	{
 	};
 
 public:
+	std::string name;
+	bool primary;
 	int x;
 	int y;
 	uint width;
@@ -364,6 +369,7 @@ public:
 	static bool getHeadInfo(uint head, Geometry &head_info);
 	static void getHeadInfo(int x, int y, Geometry &head_info);
 	static Geometry getHeadGeometry(uint head);
+	static int findHeadByName(const std::string& name);
 	static int getNumHeads(void);
 
 	static Atom getAtom(AtomName name) { return _atoms[name]; }


### PR DESCRIPTION
This is not an option with Xinerama. But with randr we have name on
each monitor, which is visible from xrandr or its GUI equivalents.
Selecting head by name would be easier and friendlier. More
importantly, we can also find out which screen is primary from xrandr.

This patch gets that info from randr. Harbour has a new configuration to
locate head by name. MoveToHead is also improved to accept head name in
addition to number. CurrHeadSelector could be enhanced too, but I'm not
sure if it's really useful