### PR TITLE
Automatically set fullscreen on fullscreen-sized window

### DIFF
--- a/src/Client.cc
+++ b/src/Client.cc
@@ -353,6 +353,13 @@ Client::setInitialState(void)
 		_iconified = true;
 	}
 
+	if (! _iconified) {
+		Geometry head_gm = X11::getHeadGeometry(X11Util::getNearestHead(*this));
+		if (! isCfgDeny(CFG_DENY_STATE_FULLSCREEN) && _gm == head_gm) {
+			_state.fullscreen = true;
+		}
+	}
+
 	if (_iconified || initial_state == IconicState) {
 		_iconified = true;
 		_mapped = true;


### PR DESCRIPTION
This may or may not be the right thing to do. So this is more like a way
to start a discussion than suggesting a change.

The problem: firefox has this feature called "Picture-in-Picture" that
allows you to pop a video out as a separate window. When you close it
and pop again, the last window size and position are remembered and
restored.

Now imagine you pop it up, set full screen and close it. Then pop again.
The second time the window fills the screen but it's not really a
fullscreen window so it has decoration and everything. This change
detects the case and automatically set it back to full screen.

Interestingly, mutter (GNOME WM) has this behavior too for legacy apps.
See
https://gitlab.gnome.org/GNOME/mutter/-/commit/fba022cc06b8c7e80ef36f48d6577a251384cc4b.
The behavior can be disabled but on by default.

Next problem: it's cool that it's fullscreen. But when you un-fullscreen
it, because there's no original window size before fullscreen, the
window still kinda fills up the screen, but this time with decoration.